### PR TITLE
feat: add prefer example implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ docker run -v "$PWD/myschema.json:/app/schema.json" -p "3000:3000" jormaechea/op
 - [x] Request parameters validation
 - [x] Request body validation
 - [x] Response body and headers generation based on examples or schemas
-- [x] Response selection based using `Prefer: statusCode=XXX` request header.
+- [x] Response selection using request header: `Prefer: statusCode=XXX` or `Prefer: example=name` 
 - [x] Request and response logging
 - [x] Servers basepath support
 - [ ] API Authentication

--- a/lib/components/responses/structs.js
+++ b/lib/components/responses/structs.js
@@ -32,7 +32,16 @@ const MediaTypeStruct = struct.interface({
 		SchemaStruct,
 		ReferenceStruct
 	])),
-	example: struct.optional(struct.union(['string', 'number', 'boolean', 'object', 'array']))
+	example: struct.optional(struct.union(['string', 'number', 'boolean', 'object', 'array'])),
+	examples: struct.optional(struct.dict(['string', struct.intersection([
+		'object',
+		struct.interface({
+			summary: 'string?',
+			description: 'string?',
+			value: struct.union(['string', 'number', 'boolean', 'object', 'array']),
+			externalValue: 'string?'
+		})
+	])]))
 });
 
 const LinkStruct = struct.intersection([

--- a/lib/mocker/express/server.js
+++ b/lib/mocker/express/server.js
@@ -8,6 +8,7 @@ const cors = require('cors');
 const cookieParser = require('cookie-parser');
 const logger = require('lllog')();
 const colors = require('colors');
+const parsePreferHeader = require('parse-prefer-header');
 
 const openApiMockSymbol = Symbol('openApiMock');
 
@@ -95,14 +96,14 @@ class Server {
 					return this.sendResponse(res, { errors: failedValidations }, 400);
 
 				const preferHeader = req.header('prefer') || '';
-				const [, preferStatusCode] = preferHeader.match(/statusCode=(\d{3})/) || [];
+				const { example: preferredExampleName, statusCode: preferredStatusCode } = parsePreferHeader(preferHeader) || {};
 
-				if(preferStatusCode)
-					logger.debug(`Searching requested response with status code ${preferStatusCode}`);
+				if(preferredStatusCode)
+					logger.debug(`Searching requested response with status code ${preferredStatusCode}`);
 				else
 					logger.debug('Searching first response');
 
-				const { statusCode, headers: responseHeaders, body } = path.getResponse(preferStatusCode);
+				const { statusCode, headers: responseHeaders, body } = path.getResponse(preferredStatusCode, preferredExampleName);
 
 				return this.sendResponse(res, body, statusCode, responseHeaders);
 			});

--- a/lib/paths/path.js
+++ b/lib/paths/path.js
@@ -209,7 +209,7 @@ class Path {
 		return !possibleValues || !possibleValues.length || possibleValues.includes(value);
 	}
 
-	getResponse(preferredStatusCode) {
+	getResponse(preferredStatusCode, preferredExampleName) {
 
 		const {
 			statusCode,
@@ -220,7 +220,7 @@ class Path {
 		return {
 			statusCode: Number(statusCode),
 			headers: headers && this.generateResponseHeaders(headers),
-			body: schema ? ResponseGenerator.generate(schema) : null
+			body: schema ? ResponseGenerator.generate(schema, preferredExampleName) : null
 		};
 	}
 

--- a/lib/response-generator/index.js
+++ b/lib/response-generator/index.js
@@ -8,8 +8,8 @@ class ResponseGenerator {
 			return schemaResponse.example;
 
 		if(schemaResponse.examples && Object.values(schemaResponse.examples).length) {
-			if(preferredExampleName)
-				return schemaResponse.examples[preferredExampleName] && schemaResponse.examples[preferredExampleName].value || Object.values(schemaResponse.examples)[0].value;
+			if(preferredExampleName && schemaResponse.examples[preferredExampleName])
+				return schemaResponse.examples[preferredExampleName].value || Object.values(schemaResponse.examples)[0].value;
 			return Object.values(schemaResponse.examples)[0].value;
 		}
 

--- a/lib/response-generator/index.js
+++ b/lib/response-generator/index.js
@@ -9,7 +9,7 @@ class ResponseGenerator {
 
 		if(schemaResponse.examples && Object.values(schemaResponse.examples).length) {
 			if(preferredExampleName && schemaResponse.examples[preferredExampleName] && schemaResponse.examples[preferredExampleName].value)
-				return schemaResponse.examples[preferredExampleName].value
+				return schemaResponse.examples[preferredExampleName].value;
 			if(Object.values(schemaResponse.examples)[0].value)
 				return Object.values(schemaResponse.examples)[0].value;
 		}

--- a/lib/response-generator/index.js
+++ b/lib/response-generator/index.js
@@ -9,8 +9,8 @@ class ResponseGenerator {
 
 		if(schemaResponse.examples && Object.values(schemaResponse.examples).length) {
 			if(preferredExampleName)
-				return schemaResponse.examples[preferredExampleName] || Object.values(schemaResponse.examples)[0];
-			return schemaResponse.examples[0];
+				return schemaResponse.examples[preferredExampleName] && schemaResponse.examples[preferredExampleName].value || Object.values(schemaResponse.examples)[0].value;
+			return Object.values(schemaResponse.examples)[0].value;
 		}
 
 		if(schemaResponse.enum && schemaResponse.enum.length)

--- a/lib/response-generator/index.js
+++ b/lib/response-generator/index.js
@@ -8,9 +8,10 @@ class ResponseGenerator {
 			return schemaResponse.example;
 
 		if(schemaResponse.examples && Object.values(schemaResponse.examples).length) {
-			if(preferredExampleName && schemaResponse.examples[preferredExampleName])
-				return schemaResponse.examples[preferredExampleName].value || Object.values(schemaResponse.examples)[0].value;
-			return Object.values(schemaResponse.examples)[0].value;
+			if(preferredExampleName && schemaResponse.examples[preferredExampleName] && schemaResponse.examples[preferredExampleName].value)
+				return schemaResponse.examples[preferredExampleName].value
+			if(Object.values(schemaResponse.examples)[0].value)
+				return Object.values(schemaResponse.examples)[0].value;
 		}
 
 		if(schemaResponse.enum && schemaResponse.enum.length)

--- a/lib/response-generator/index.js
+++ b/lib/response-generator/index.js
@@ -2,13 +2,16 @@
 
 class ResponseGenerator {
 
-	static generate(schemaResponse) {
+	static generate(schemaResponse, preferredExampleName) {
 
 		if(schemaResponse.example)
 			return schemaResponse.example;
 
-		if(schemaResponse.examples && schemaResponse.examples.length)
+		if(schemaResponse.examples && Object.values(schemaResponse.examples).length) {
+			if(preferredExampleName)
+				return schemaResponse.examples[preferredExampleName] || Object.values(schemaResponse.examples)[0];
 			return schemaResponse.examples[0];
+		}
 
 		if(schemaResponse.enum && schemaResponse.enum.length)
 			return this.generateByEnum(schemaResponse.enum);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2187,6 +2187,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+    },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -2950,6 +2955,14 @@
       "dev": true,
       "requires": {
         "error-ex": "^1.2.0"
+      }
+    },
+    "parse-prefer-header": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-prefer-header/-/parse-prefer-header-1.0.0.tgz",
+      "integrity": "sha1-da63N2a7ZTHd4GPuAjh26tSWSPc=",
+      "requires": {
+        "lodash.camelcase": "^4.3.0"
       }
     },
     "parseurl": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "js-yaml": "^3.14.0",
     "json-refs": "^3.0.13",
     "lllog": "^1.1.2",
+    "parse-prefer-header": "^1.0.0",
     "superstruct": "^0.6.1",
     "yargs": "^13.3.0"
   },

--- a/tests/paths/path.js
+++ b/tests/paths/path.js
@@ -1816,10 +1816,10 @@ describe('Paths', () => {
 							'application/json': {
 								examples: {
 									hello: {
-										message: 'world'
+										value: { hello: 'world' }
 									},
 									goodbye: {
-										message: 'yellow brick road'
+										value: { goodbye: 'yellow brick road' }
 									}
 								}
 							}
@@ -1834,7 +1834,7 @@ describe('Paths', () => {
 				statusCode: 200,
 				headers: undefined,
 				body: {
-					message: 'yellow brick road'
+					goodbye: 'yellow brick road'
 				}
 			});
 		});
@@ -1852,10 +1852,10 @@ describe('Paths', () => {
 							'application/json': {
 								examples: {
 									hello: {
-										message: 'world'
+										value: { hello: 'world' }
 									},
 									goodbye: {
-										message: 'yellow brick road'
+										value: { goodbye: 'yellow brick road' }
 									}
 								}
 							}
@@ -1870,7 +1870,7 @@ describe('Paths', () => {
 				statusCode: 200,
 				headers: undefined,
 				body: {
-					message: 'world'
+					hello: 'world'
 				}
 			});
 		});
@@ -1939,10 +1939,14 @@ describe('Paths', () => {
 							'application/json': {
 								examples: {
 									invalid: {
-										message: 'Unauthorized - token invalid'
+										value: {
+											message: 'Unauthorized - token invalid'
+										}
 									},
 									expired: {
-										message: 'Unauthorized - token expired'
+										value: {
+											message: 'Unauthorized - token expired'
+										}
 									}
 								}
 							}

--- a/tests/paths/path.js
+++ b/tests/paths/path.js
@@ -1803,6 +1803,78 @@ describe('Paths', () => {
 			});
 		});
 
+		it('Should call the response generator with the first available response with given example if no preferred statusCode is passed', () => {
+
+			const path = new Path({
+				uri: '/hello',
+				httpMethod: 'get',
+				parameters: undefined,
+				responses: {
+					200: {
+						description: 'OK',
+						content: {
+							'application/json': {
+								examples: {
+									hello: {
+										message: 'world'
+									},
+									goodbye: {
+										message: 'yellow brick road'
+									}
+								}
+							}
+						}
+					}
+				}
+			});
+
+			const response = path.getResponse(undefined, 'goodbye');
+
+			assert.deepStrictEqual(response, {
+				statusCode: 200,
+				headers: undefined,
+				body: {
+					message: 'yellow brick road'
+				}
+			});
+		});
+
+		it('Should call the response generator with the first available response with prefer example & no prefered statusCode, but no match', () => {
+
+			const path = new Path({
+				uri: '/hello',
+				httpMethod: 'get',
+				parameters: undefined,
+				responses: {
+					200: {
+						description: 'OK',
+						content: {
+							'application/json': {
+								examples: {
+									hello: {
+										message: 'world'
+									},
+									goodbye: {
+										message: 'yellow brick road'
+									}
+								}
+							}
+						}
+					}
+				}
+			});
+
+			const response = path.getResponse(undefined, 'sup');
+
+			assert.deepStrictEqual(response, {
+				statusCode: 200,
+				headers: undefined,
+				body: {
+					message: 'world'
+				}
+			});
+		});
+
 		it('Should call the response generator with the preferred response based on the passed statusCode', () => {
 
 			const path = new Path({
@@ -1840,6 +1912,52 @@ describe('Paths', () => {
 				headers: undefined,
 				body: {
 					message: 'Unauthorized'
+				}
+			});
+		});
+
+		it('Should call the response generator with the preferred response based on the passed statusCode and passed example', () => {
+
+			const path = new Path({
+				uri: '/hello',
+				httpMethod: 'get',
+				parameters: undefined,
+				responses: {
+					200: {
+						description: 'OK',
+						content: {
+							'application/json': {
+								example: {
+									hello: 'world'
+								}
+							}
+						}
+					},
+					401: {
+						description: 'Unauthorized',
+						content: {
+							'application/json': {
+								examples: {
+									invalid: {
+										message: 'Unauthorized - token invalid'
+									},
+									expired: {
+										message: 'Unauthorized - token expired'
+									}
+								}
+							}
+						}
+					}
+				}
+			});
+
+			const response = path.getResponse('401', 'expired');
+
+			assert.deepStrictEqual(response, {
+				statusCode: 401,
+				headers: undefined,
+				body: {
+					message: 'Unauthorized - token expired'
 				}
 			});
 		});

--- a/tests/response-generator/index.js
+++ b/tests/response-generator/index.js
@@ -38,6 +38,47 @@ describe('Response Generator', () => {
 			});
 		});
 
+		it('Should return the preferred example if prefer header is set', () => {
+
+			const responseSchema = {
+				examples: {
+					cat: {
+						summary: 'An example of a cat',
+						value: {
+							name: 'Fluffy',
+							petType: 'Cat',
+							color: 'White',
+							gender: 'male',
+							breed: 'Persian'
+						}
+					},
+					dog: {
+						summary: 'An example of a dog with a cat\'s name',
+						value: {
+							name: 'Puma',
+							petType: 'Dog',
+							color: 'Black',
+							gender: 'Female',
+							breed: 'Mixed'
+						}
+					}
+				}
+			};
+
+			const response = ResponseGenerator.generate(responseSchema, 'cat');
+
+			assert.deepStrictEqual(response, {
+				summary: 'An example of a cat',
+				value: {
+					name: 'Fluffy',
+					petType: 'Cat',
+					color: 'White',
+					gender: 'male',
+					breed: 'Persian'
+				}
+			});
+		});
+
 		it('Should return the schema\'s example if it\'s defined', () => {
 
 			const responseSchema = {

--- a/tests/response-generator/index.js
+++ b/tests/response-generator/index.js
@@ -26,9 +26,13 @@ describe('Response Generator', () => {
 		it('Should return the first example if examples is defined', () => {
 
 			const responseSchema = {
-				examples: [{
-					foo: 'bar'
-				}]
+				examples: {
+					first: {
+						value: {
+							foo: 'bar'
+						}
+					}	
+				}
 			};
 
 			const response = ResponseGenerator.generate(responseSchema);
@@ -65,17 +69,14 @@ describe('Response Generator', () => {
 				}
 			};
 
-			const response = ResponseGenerator.generate(responseSchema, 'cat');
+			const response = ResponseGenerator.generate(responseSchema, 'dog');
 
 			assert.deepStrictEqual(response, {
-				summary: 'An example of a cat',
-				value: {
-					name: 'Fluffy',
-					petType: 'Cat',
-					color: 'White',
-					gender: 'male',
-					breed: 'Persian'
-				}
+				name: 'Puma',
+				petType: 'Dog',
+				color: 'Black',
+				gender: 'Female',
+				breed: 'Mixed'
 			});
 		});
 

--- a/tests/response-generator/index.js
+++ b/tests/response-generator/index.js
@@ -67,7 +67,7 @@ describe('Response Generator', () => {
 					},
 					second: {
 						hello: 'goodbye'
-					},
+					}
 				}
 			};
 

--- a/tests/response-generator/index.js
+++ b/tests/response-generator/index.js
@@ -31,7 +31,7 @@ describe('Response Generator', () => {
 						value: {
 							foo: 'bar'
 						}
-					}	
+					}
 				}
 			};
 

--- a/tests/response-generator/index.js
+++ b/tests/response-generator/index.js
@@ -42,6 +42,42 @@ describe('Response Generator', () => {
 			});
 		});
 
+		it('Should throw if examples is defined but example has no value', () => {
+
+			const responseSchema = {
+				examples: {
+					first: {
+						foo: 'bar'
+					}
+				}
+			};
+
+			assert.throws(() => ResponseGenerator.generate(responseSchema));
+		});
+
+
+		it('Should return the first example if examples is defined & preferred example value undefined', () => {
+
+			const responseSchema = {
+				examples: {
+					first: {
+						value: {
+							yes: 'no'
+						}
+					},
+					second: {
+						hello: 'goodbye'
+					},
+				}
+			};
+
+			const response = ResponseGenerator.generate(responseSchema, 'second');
+
+			assert.deepStrictEqual(response, {
+				yes: 'no'
+			});
+		});
+
 		it('Should return the preferred example if prefer header is set', () => {
 
 			const responseSchema = {


### PR DESCRIPTION
Implemented a Prefer header option for examples, in addition to the same Prefer header for selecting response statusCodes.

Use case: multiple possible examples for a given endpoint or status code. For example, on some endpoints a 200 could return many possible responses. This implementation allows you to select which one in the same way you select a response code. 

The selection is hierarchical in nature in that it selects a response code first, then example name if available. It sets reasonable defaults in the case of error. Similar to other functionality, if the requested response from the prefer header isn't available it defaults. 

A couple notes: 
- according to the spec, and example could be defined in the schema object, not just the Media Type Object https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#media-type-object Examples defined at this level override the schema level declaration. I'm not sure the current code does that. 
- This implementation aspires to leave as much code untouched as possible, though the increasing possibility of Prefer options means that in the future passing these options by a single object (rather than ever increasing function arity) might be preferable. 
- Code coverage is still 100%
- Currently testing this against a project of mine, will move to a real PR once that and additional notes in the README are written. 

Last, I'm impressed at the quality of this project. Well written, easy to follow, well tested. If only all OSS projects were this good. 