### PR TITLE
Extension handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ jspm_packages
 # Test and coverage reports
 coverage/
 .nyc_output/
+
+# Editor configuration files
+.idea/

--- a/README.md
+++ b/README.md
@@ -45,7 +45,109 @@ docker run -v "$PWD/myschema.json:/app/schema.json" -p "3000:3000" jormaechea/op
 - [x] Response selection using request header: `Prefer: statusCode=XXX` or `Prefer: example=name` 
 - [x] Request and response logging
 - [x] Servers basepath support
+- [x] Support x-faker and x-count extension methods to customise generated responses
 - [ ] API Authentication
+
+## Customizing Generated Responses
+The OpenAPI specification allows custom properties to be added to an API definition in the form of _x-*_.
+OpenAPI Mocker supports the use of two custom extensions to allow data to be randomised which should allow for more 
+realistic looking data when developing a UI against a mock API for instance.
+
+### x-faker
+The _x-faker_ extension is valid for use on properties that have a primitive type (e.g. `string`/`integer`, etc.) 
+and can be used within an API definition to use one or more methods from the excellent 
+[faker](https://www.npmjs.com/package/faker) library for generating random data.
+
+Given the following API definition:
+```yaml
+openapi: '3.0.2'
+info:
+  title: Cats
+  version: '1.0'
+servers:
+  - url: https://api.cats.test/v1
+paths:
+  /cat:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  firstName:
+                    type: string
+                    x-faker: name.firstName
+                  lastName:
+                    type: string
+                    x-faker: name.lastName
+                  fullName:
+                    type: string
+                    x-faker: '{{name.firstName}} {{name.lastName}}'
+                  age:
+                    type: string
+                    x-faker: 'random.number({ "min": 1, "max": 20 })'
+                  
+``` 
+
+A JSON response similar to the following would be produced:
+```JSON
+{
+    "firstName": "Ted",
+    "lastName": "Kozey",
+    "fullName": "Herbert Lowe",
+    "age": 12
+}
+```
+
+The _x-faker_ extension accepts values in 3 forms:
+1. _fakerNamespace.method_. e.g. `random.uuid`
+2. _fakerNamespace.method({ "methodArgs": "in", "json": "format" })_. e.g. `random.number({ "max": 100 })`
+3. A mustache template string making use of the 2 forms above. e.g. `My name is {{name.firstName}} {{name.lastName}}`
+
+*NOTE*: To avoid new fake data from being generated on every call, up to 10 responses per endpoint is cached 
+that is based on the incoming query string, request body and headers.
+
+### x-count
+The _x-count_ extension only as affect when used on a `array` type property.
+If encountered, OpenAPI Mocker will return an array with the given number of elements instead of the default of an 
+array with a single item.
+
+For example, the following API definition:
+```yaml
+openapi: '3.0.2'
+info:
+  title: Cats
+  version: '1.0'
+servers:
+  - url: https://api.cats.test/v1
+paths:
+  /cat:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                x-count: 5
+                items:
+                  type: string
+```
+
+Will produce the following response:
+```JSON
+[
+    "string",
+    "string",
+    "string",
+    "string",
+    "string"
+]
+```
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ The _x-faker_ extension accepts values in 3 forms:
 2. _fakerNamespace.method({ "methodArgs": "in", "json": "format" })_. e.g. `random.number({ "max": 100 })`
 3. A mustache template string making use of the 2 forms above. e.g. `My name is {{name.firstName}} {{name.lastName}}`
 
-*NOTE*: To avoid new fake data from being generated on every call, up to 10 responses per endpoint is cached 
-that is based on the incoming query string, request body and headers.
+*NOTE*: To avoid new fake data from being generated on every call, up to 10 responses per endpoint are cached 
+based on the incoming query string, request body and headers.
 
 ### x-count
-The _x-count_ extension only as affect when used on a `array` type property.
+The _x-count_ extension has effect only when used on an `array` type property.
 If encountered, OpenAPI Mocker will return an array with the given number of elements instead of the default of an 
 array with a single item.
 

--- a/lib/mocker/express/server.js
+++ b/lib/mocker/express/server.js
@@ -35,10 +35,6 @@ class Server {
 		return this;
 	}
 
-	getResponse() {
-
-	}
-
 	async init() {
 
 		if(this.server)

--- a/lib/mocker/express/server.js
+++ b/lib/mocker/express/server.js
@@ -9,6 +9,7 @@ const cookieParser = require('cookie-parser');
 const logger = require('lllog')();
 const colors = require('colors');
 const parsePreferHeader = require('parse-prefer-header');
+const memoize = require('micro-memoize');
 
 const openApiMockSymbol = Symbol('openApiMock');
 
@@ -32,6 +33,10 @@ class Server {
 	setPaths(paths) {
 		this.paths = paths;
 		return this;
+	}
+
+	getResponse() {
+
 	}
 
 	async init() {
@@ -73,6 +78,26 @@ class Server {
 
 			const uris = this._normalizeExpressPath(path.uri);
 
+			const getResponse = (url, query, preferHeader) => {
+				const { example: preferredExampleName, statusCode: preferredStatusCode } = parsePreferHeader(preferHeader) || {};
+
+				if(preferredStatusCode)
+					logger.debug(`Searching requested response with status code ${preferredStatusCode}`);
+				else
+					logger.debug('Searching first response');
+				return path.getResponse(preferredStatusCode, preferredExampleName);
+			};
+
+			const getResponseMemo = memoize(getResponse, {
+				maxSize: 10,
+				onCacheAdd: () => {
+					console.log('cache added');
+				},
+				onCacheHit: () => {
+					console.log('cache hit');
+				}
+			});
+
 			app[expressHttpMethod](uris, (req, res) => {
 
 				this._checkContentType(req);
@@ -97,14 +122,8 @@ class Server {
 					return this.sendResponse(res, { errors: failedValidations }, 400);
 
 				const preferHeader = req.header('prefer') || '';
-				const { example: preferredExampleName, statusCode: preferredStatusCode } = parsePreferHeader(preferHeader) || {};
 
-				if(preferredStatusCode)
-					logger.debug(`Searching requested response with status code ${preferredStatusCode}`);
-				else
-					logger.debug('Searching first response');
-
-				const { statusCode, headers: responseHeaders, body } = path.getResponse(preferredStatusCode, preferredExampleName);
+				const { statusCode, headers: responseHeaders, body } = getResponseMemo(req.path, JSON.stringify(req.query), preferHeader);
 
 				return this.sendResponse(res, body, statusCode, responseHeaders);
 			});

--- a/lib/mocker/express/server.js
+++ b/lib/mocker/express/server.js
@@ -78,7 +78,9 @@ class Server {
 
 			const uris = this._normalizeExpressPath(path.uri);
 
-			const getResponse = (url, query, preferHeader) => {
+			// Create a function that is memoized using the URL, query, the Prefer header and the body.
+			// eslint-disable-next-line no-unused-vars
+			const getResponse = (url, query, preferHeader, body) => {
 				const { example: preferredExampleName, statusCode: preferredStatusCode } = parsePreferHeader(preferHeader) || {};
 
 				if(preferredStatusCode)
@@ -89,13 +91,7 @@ class Server {
 			};
 
 			const getResponseMemo = memoize(getResponse, {
-				maxSize: 10,
-				onCacheAdd: () => {
-					console.log('cache added');
-				},
-				onCacheHit: () => {
-					console.log('cache hit');
-				}
+				maxSize: 10
 			});
 
 			app[expressHttpMethod](uris, (req, res) => {
@@ -123,7 +119,8 @@ class Server {
 
 				const preferHeader = req.header('prefer') || '';
 
-				const { statusCode, headers: responseHeaders, body } = getResponseMemo(req.path, JSON.stringify(req.query), preferHeader);
+				const { statusCode, headers: responseHeaders, body } =
+					getResponseMemo(req.path, JSON.stringify(req.query), preferHeader, JSON.stringify(requestBody));
 
 				return this.sendResponse(res, body, statusCode, responseHeaders);
 			});

--- a/lib/response-generator/index.js
+++ b/lib/response-generator/index.js
@@ -52,12 +52,12 @@ class ResponseGenerator {
 		if(schemaResponse.anyOf)
 			return this.generate(schemaResponse.anyOf[0]);
 
-		const fakerScheme = schemaResponse['X-Faker'];
-		if(fakerScheme) {
+		const fakerExtension = schemaResponse['x-faker'];
+		if(fakerExtension) {
 			try {
-				return this.generateByFaker(fakerScheme);
+				return this.generateByFaker(fakerExtension);
 			} catch(e) {
-				logger.warn(`Failed to generate fake result using ${fakerScheme} schema. Falling back to primitive type.`);
+				logger.warn(`Failed to generate fake result using ${fakerExtension} schema. Falling back to primitive type.`);
 			}
 		}
 

--- a/lib/response-generator/index.js
+++ b/lib/response-generator/index.js
@@ -127,7 +127,7 @@ class ResponseGenerator {
 		if(Number.isNaN(count) || count < 1)
 			count = 1;
 
-		return [...new Array(count).keys()].map(() => this.generate(schema.items));
+		return [...new Array(count)].map(() => this.generate(schema.items));
 	}
 
 	static generateObject(schema) {

--- a/lib/response-generator/index.js
+++ b/lib/response-generator/index.js
@@ -1,7 +1,10 @@
 'use strict';
 
-const faker = require('faker');
 const logger = require('lllog')();
+const faker = require('faker');
+
+const { locale } = Intl.DateTimeFormat().resolvedOptions();
+faker.setLocale(locale.replace('-', '_'));
 
 class ResponseGenerator {
 

--- a/lib/response-generator/index.js
+++ b/lib/response-generator/index.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const faker = require('faker');
+const logger = require('lllog')();
+
 class ResponseGenerator {
 
 	static generate(schemaResponse, preferredExampleName) {
@@ -49,6 +52,15 @@ class ResponseGenerator {
 		if(schemaResponse.anyOf)
 			return this.generate(schemaResponse.anyOf[0]);
 
+		const fakerScheme = schemaResponse['X-Faker'];
+		if(fakerScheme) {
+			try {
+				return this.generateByFaker(fakerScheme);
+			} catch(e) {
+				logger.warn(`Failed to generate fake result using ${fakerScheme} schema. Falling back to primitive type.`);
+			}
+		}
+
 		switch(schemaResponse.type) {
 
 			case 'array':
@@ -72,6 +84,10 @@ class ResponseGenerator {
 			default:
 				throw new Error('Could not generate response: unknown type');
 		}
+	}
+
+	static generateByFaker(fakerString) {
+		return faker.fake(`{{${fakerString}}}`);
 	}
 
 	static generateArray(schema) {

--- a/lib/response-generator/index.js
+++ b/lib/response-generator/index.js
@@ -87,6 +87,14 @@ class ResponseGenerator {
 	}
 
 	static generateByFaker(fakerString) {
+		// If a date function is used, we want to call the method directly to be able to get the Date object back
+		const dateMatch = /^date\.(.+)/.exec(fakerString);
+		if(dateMatch) {
+			const method = dateMatch[1];
+			const date = faker.date[method]();
+			return date.toISOString();
+		}
+
 		return faker.fake(`{{${fakerString}}}`);
 	}
 

--- a/lib/response-generator/index.js
+++ b/lib/response-generator/index.js
@@ -1,169 +1,182 @@
-"use strict";
+'use strict';
 
-const logger = require("lllog")();
-const faker = require("faker");
+const logger = require('lllog')();
+const faker = require('faker');
 
 const { locale } = Intl.DateTimeFormat().resolvedOptions();
-faker.setLocale(locale.replace("-", "_"));
+faker.setLocale(locale.replace('-', '_'));
 
 class ResponseGenerator {
-  static generate(schemaResponse, preferredExampleName) {
-    if (schemaResponse.example) return schemaResponse.example;
+	static generate(schemaResponse, preferredExampleName) {
+		if(schemaResponse.example)
+			return schemaResponse.example;
 
-    if (
-      schemaResponse.examples &&
+		if(
+			schemaResponse.examples &&
       Object.values(schemaResponse.examples).length
-    ) {
-      if (
-        preferredExampleName &&
+		) {
+			if(
+				preferredExampleName &&
         schemaResponse.examples[preferredExampleName] &&
         schemaResponse.examples[preferredExampleName].value
-      )
-        return schemaResponse.examples[preferredExampleName].value;
-      if (Object.values(schemaResponse.examples)[0].value)
-        return Object.values(schemaResponse.examples)[0].value;
-    }
+			)
+				return schemaResponse.examples[preferredExampleName].value;
+			if(Object.values(schemaResponse.examples)[0].value)
+				return Object.values(schemaResponse.examples)[0].value;
+		}
 
-    if (schemaResponse.enum && schemaResponse.enum.length)
-      return this.generateByEnum(schemaResponse.enum);
+		if(schemaResponse.enum && schemaResponse.enum.length)
+			return this.generateByEnum(schemaResponse.enum);
 
-    if (schemaResponse.schema)
-      return this.generateBySchema(schemaResponse.schema);
+		if(schemaResponse.schema)
+			return this.generateBySchema(schemaResponse.schema);
 
-    if (schemaResponse.type) return this.generateBySchema(schemaResponse);
+		if(schemaResponse.type)
+			return this.generateBySchema(schemaResponse);
 
-    throw new Error(
-      `Could not generate response: invalid schema: ${JSON.stringify(
-        schemaResponse
-      )}`
-    );
-  }
+		throw new Error(
+			`Could not generate response: invalid schema: ${JSON.stringify(
+				schemaResponse
+			)}`
+		);
+	}
 
-  static generateByEnum(enumOptions) {
-    return enumOptions[0];
-  }
+	static generateByEnum(enumOptions) {
+		return enumOptions[0];
+	}
 
-  static generateBySchema(schemaResponse) {
-    if (schemaResponse.example) return schemaResponse.example;
+	static generateBySchema(schemaResponse) {
+		if(schemaResponse.example)
+			return schemaResponse.example;
 
-    if (schemaResponse.examples && schemaResponse.examples.length)
-      return schemaResponse.examples[0];
+		if(schemaResponse.examples && schemaResponse.examples.length)
+			return schemaResponse.examples[0];
 
-    if (schemaResponse.allOf) {
-      return schemaResponse.allOf
-        .map((oneSchema) => this.generate(oneSchema))
-        .reduce(
-          (acum, oneSchemaValues) => ({ ...acum, ...oneSchemaValues }),
-          {}
-        );
-    }
+		if(schemaResponse.allOf) {
+			return schemaResponse.allOf
+				.map(oneSchema => this.generate(oneSchema))
+				.reduce(
+					(acum, oneSchemaValues) => ({ ...acum, ...oneSchemaValues }),
+					{}
+				);
+		}
 
-    if (schemaResponse.oneOf) return this.generate(schemaResponse.oneOf[0]);
+		if(schemaResponse.oneOf)
+			return this.generate(schemaResponse.oneOf[0]);
 
-    if (schemaResponse.anyOf) return this.generate(schemaResponse.anyOf[0]);
+		if(schemaResponse.anyOf)
+			return this.generate(schemaResponse.anyOf[0]);
 
-    const fakerExtension = schemaResponse["x-faker"];
-    if (fakerExtension) {
-      try {
-        return this.generateByFaker(fakerExtension);
-      } catch (e) {
-        logger.warn(
-          `Failed to generate fake result using ${fakerExtension} schema. Falling back to primitive type.`
-        );
-      }
-    }
+		const fakerExtension = schemaResponse['x-faker'];
+		if(fakerExtension) {
+			try {
+				return this.generateByFaker(fakerExtension);
+			} catch(e) {
+				logger.warn(
+					`Failed to generate fake result using ${fakerExtension} schema. Falling back to primitive type.`
+				);
+			}
+		}
 
-    switch (schemaResponse.type) {
-      case "array":
-        return this.generateArray(schemaResponse);
+		switch(schemaResponse.type) {
+			case 'array':
+				return this.generateArray(schemaResponse);
 
-      case "object":
-        return this.generateObject(schemaResponse);
+			case 'object':
+				return this.generateObject(schemaResponse);
 
-      case "string":
-        return this.generateString(schemaResponse);
+			case 'string':
+				return this.generateString(schemaResponse);
 
-      case "number":
-        return this.generateNumber(schemaResponse);
+			case 'number':
+				return this.generateNumber(schemaResponse);
 
-      case "integer":
-        return this.generateInteger(schemaResponse);
+			case 'integer':
+				return this.generateInteger(schemaResponse);
 
-      case "boolean":
-        return this.generateBoolean(schemaResponse);
+			case 'boolean':
+				return this.generateBoolean(schemaResponse);
 
-      default:
-        throw new Error("Could not generate response: unknown type");
-    }
-  }
+			default:
+				throw new Error('Could not generate response: unknown type');
+		}
+	}
 
-  static generateByFaker(fakerString) {
-    const fakerRegex = /^(?<namespace>\w+)\.(?<method>\w+)(?:\((?<argsString>.*)\))?$/.exec(
-      fakerString
-    );
-    if (!fakerRegex)
-      throw new Error(
-        "Faker extension method is not in the right format. Expecting <namespace>.<method>(<args>) format."
-      );
+	static generateByFaker(fakerString) {
+		// Check if faker string is a template string
+		if(fakerString.includes('{{') && fakerString.includes('}}'))
+			return faker.fake(fakerString);
 
-    const { namespace, method, argsString } = fakerRegex.groups;
-    if (!namespace in faker)
-      throw new Error(
-        `Invalid faker namespace used. Must be one of ${Object.keys(faker).join(
-          ","
-        )}`
-      );
-    if (!method in faker[namespace])
-      throw new Error(
-        `Method '${method}' not found in faker namespace '${namespace}'. Must be one of ${Object.keys(
-          faker[namespace]
-        ).join(",")}`
-      );
+		const fakerRegex = /^(?<namespace>\w+)\.(?<method>\w+)(?:\((?<argsString>.*)\))?$/.exec(
+			fakerString
+		);
+		if(!fakerRegex) {
+			throw new Error(
+				'Faker extension method is not in the right format. Expecting <namespace>.<method>(<args>) format.'
+			);
+		}
 
-    const args = argsString ? JSON.parse(`[${argsString}]`) : [];
+		const { namespace, method, argsString } = fakerRegex.groups;
+		if(!(namespace in faker)) {
+			throw new Error(
+				`Invalid faker namespace used. Must be one of ${Object.keys(faker).join(
+					','
+				)}`
+			);
+		}
+		if(!(method in faker[namespace])) {
+			throw new Error(
+				`Method '${method}' not found in faker namespace '${namespace}'. Must be one of ${Object.keys(
+					faker[namespace]
+				).join(',')}`
+			);
+		}
 
-    return faker[namespace][method](...args);
-  }
+		const args = argsString ? JSON.parse(`[${argsString}]`) : [];
 
-  static generateArray(schema) {
-    let count = Number(schema["x-count"]);
-    if (Number.isNaN(count) || count < 1) count = 1;
+		return faker[namespace][method](...args);
+	}
 
-    return [...new Array(count).keys()].map(() => this.generate(schema.items));
-  }
+	static generateArray(schema) {
+		let count = Number(schema['x-count']);
+		if(Number.isNaN(count) || count < 1)
+			count = 1;
 
-  static generateObject(schema) {
-    const properties = schema.properties || {};
+		return [...new Array(count).keys()].map(() => this.generate(schema.items));
+	}
 
-    return Object.entries(properties)
-      .map(([property, propertySchema]) => [
-        property,
-        this.generate(propertySchema),
-      ])
-      .reduce(
-        (acum, [property, value]) => ({
-          ...acum,
-          [property]: value,
-        }),
-        {}
-      );
-  }
+	static generateObject(schema) {
+		const properties = schema.properties || {};
 
-  static generateString() {
-    return "string";
-  }
+		return Object.entries(properties)
+			.map(([property, propertySchema]) => [
+				property,
+				this.generate(propertySchema)
+			])
+			.reduce(
+				(acum, [property, value]) => ({
+					...acum,
+					[property]: value
+				}),
+				{}
+			);
+	}
 
-  static generateNumber() {
-    return 1;
-  }
+	static generateString() {
+		return 'string';
+	}
 
-  static generateInteger() {
-    return 1;
-  }
+	static generateNumber() {
+		return 1;
+	}
 
-  static generateBoolean() {
-    return true;
-  }
+	static generateInteger() {
+		return 1;
+	}
+
+	static generateBoolean() {
+		return true;
+	}
 }
 
 module.exports = ResponseGenerator;

--- a/lib/response-generator/index.js
+++ b/lib/response-generator/index.js
@@ -11,15 +11,8 @@ class ResponseGenerator {
 		if(schemaResponse.example)
 			return schemaResponse.example;
 
-		if(
-			schemaResponse.examples &&
-      Object.values(schemaResponse.examples).length
-		) {
-			if(
-				preferredExampleName &&
-        schemaResponse.examples[preferredExampleName] &&
-        schemaResponse.examples[preferredExampleName].value
-			)
+		if(schemaResponse.examples && Object.values(schemaResponse.examples).length) {
+			if(preferredExampleName && schemaResponse.examples[preferredExampleName] && schemaResponse.examples[preferredExampleName].value)
 				return schemaResponse.examples[preferredExampleName].value;
 			if(Object.values(schemaResponse.examples)[0].value)
 				return Object.values(schemaResponse.examples)[0].value;
@@ -34,11 +27,7 @@ class ResponseGenerator {
 		if(schemaResponse.type)
 			return this.generateBySchema(schemaResponse);
 
-		throw new Error(
-			`Could not generate response: invalid schema: ${JSON.stringify(
-				schemaResponse
-			)}`
-		);
+		throw new Error(`Could not generate response: invalid schema: ${JSON.stringify(schemaResponse)}`);
 	}
 
 	static generateByEnum(enumOptions) {
@@ -53,12 +42,8 @@ class ResponseGenerator {
 			return schemaResponse.examples[0];
 
 		if(schemaResponse.allOf) {
-			return schemaResponse.allOf
-				.map(oneSchema => this.generate(oneSchema))
-				.reduce(
-					(acum, oneSchemaValues) => ({ ...acum, ...oneSchemaValues }),
-					{}
-				);
+			return schemaResponse.allOf.map(oneSchema => this.generate(oneSchema))
+				.reduce((acum, oneSchemaValues) => ({ ...acum, ...oneSchemaValues }), {});
 		}
 
 		if(schemaResponse.oneOf)
@@ -146,20 +131,15 @@ class ResponseGenerator {
 	}
 
 	static generateObject(schema) {
+
 		const properties = schema.properties || {};
 
 		return Object.entries(properties)
-			.map(([property, propertySchema]) => [
-				property,
-				this.generate(propertySchema)
-			])
-			.reduce(
-				(acum, [property, value]) => ({
-					...acum,
-					[property]: value
-				}),
-				{}
-			);
+			.map(([property, propertySchema]) => ([property, this.generate(propertySchema)]))
+			.reduce((acum, [property, value]) => ({
+				...acum,
+				[property]: value
+			}), {});
 	}
 
 	static generateString() {
@@ -177,6 +157,7 @@ class ResponseGenerator {
 	static generateBoolean() {
 		return true;
 	}
+
 }
 
 module.exports = ResponseGenerator;

--- a/lib/response-generator/index.js
+++ b/lib/response-generator/index.js
@@ -91,7 +91,11 @@ class ResponseGenerator {
 	}
 
 	static generateArray(schema) {
-		return [this.generate(schema.items)];
+		let count = Number(schema['x-count']);
+		if(Number.isNaN(count) || count < 1)
+			count = 1;
+
+		return [...new Array(count).keys()].map(() => this.generate(schema.items));
 	}
 
 	static generateObject(schema) {

--- a/lib/response-generator/index.js
+++ b/lib/response-generator/index.js
@@ -1,142 +1,169 @@
-'use strict';
+"use strict";
 
-const logger = require('lllog')();
-const faker = require('faker');
+const logger = require("lllog")();
+const faker = require("faker");
 
 const { locale } = Intl.DateTimeFormat().resolvedOptions();
-faker.setLocale(locale.replace('-', '_'));
+faker.setLocale(locale.replace("-", "_"));
 
 class ResponseGenerator {
+  static generate(schemaResponse, preferredExampleName) {
+    if (schemaResponse.example) return schemaResponse.example;
 
-	static generate(schemaResponse, preferredExampleName) {
+    if (
+      schemaResponse.examples &&
+      Object.values(schemaResponse.examples).length
+    ) {
+      if (
+        preferredExampleName &&
+        schemaResponse.examples[preferredExampleName] &&
+        schemaResponse.examples[preferredExampleName].value
+      )
+        return schemaResponse.examples[preferredExampleName].value;
+      if (Object.values(schemaResponse.examples)[0].value)
+        return Object.values(schemaResponse.examples)[0].value;
+    }
 
-		if(schemaResponse.example)
-			return schemaResponse.example;
+    if (schemaResponse.enum && schemaResponse.enum.length)
+      return this.generateByEnum(schemaResponse.enum);
 
-		if(schemaResponse.examples && Object.values(schemaResponse.examples).length) {
-			if(preferredExampleName && schemaResponse.examples[preferredExampleName] && schemaResponse.examples[preferredExampleName].value)
-				return schemaResponse.examples[preferredExampleName].value;
-			if(Object.values(schemaResponse.examples)[0].value)
-				return Object.values(schemaResponse.examples)[0].value;
-		}
+    if (schemaResponse.schema)
+      return this.generateBySchema(schemaResponse.schema);
 
-		if(schemaResponse.enum && schemaResponse.enum.length)
-			return this.generateByEnum(schemaResponse.enum);
+    if (schemaResponse.type) return this.generateBySchema(schemaResponse);
 
-		if(schemaResponse.schema)
-			return this.generateBySchema(schemaResponse.schema);
+    throw new Error(
+      `Could not generate response: invalid schema: ${JSON.stringify(
+        schemaResponse
+      )}`
+    );
+  }
 
-		if(schemaResponse.type)
-			return this.generateBySchema(schemaResponse);
+  static generateByEnum(enumOptions) {
+    return enumOptions[0];
+  }
 
-		throw new Error(`Could not generate response: invalid schema: ${JSON.stringify(schemaResponse)}`);
-	}
+  static generateBySchema(schemaResponse) {
+    if (schemaResponse.example) return schemaResponse.example;
 
-	static generateByEnum(enumOptions) {
-		return enumOptions[0];
-	}
+    if (schemaResponse.examples && schemaResponse.examples.length)
+      return schemaResponse.examples[0];
 
-	static generateBySchema(schemaResponse) {
+    if (schemaResponse.allOf) {
+      return schemaResponse.allOf
+        .map((oneSchema) => this.generate(oneSchema))
+        .reduce(
+          (acum, oneSchemaValues) => ({ ...acum, ...oneSchemaValues }),
+          {}
+        );
+    }
 
-		if(schemaResponse.example)
-			return schemaResponse.example;
+    if (schemaResponse.oneOf) return this.generate(schemaResponse.oneOf[0]);
 
-		if(schemaResponse.examples && schemaResponse.examples.length)
-			return schemaResponse.examples[0];
+    if (schemaResponse.anyOf) return this.generate(schemaResponse.anyOf[0]);
 
-		if(schemaResponse.allOf) {
-			return schemaResponse.allOf.map(oneSchema => this.generate(oneSchema))
-				.reduce((acum, oneSchemaValues) => ({ ...acum, ...oneSchemaValues }), {});
-		}
+    const fakerExtension = schemaResponse["x-faker"];
+    if (fakerExtension) {
+      try {
+        return this.generateByFaker(fakerExtension);
+      } catch (e) {
+        logger.warn(
+          `Failed to generate fake result using ${fakerExtension} schema. Falling back to primitive type.`
+        );
+      }
+    }
 
-		if(schemaResponse.oneOf)
-			return this.generate(schemaResponse.oneOf[0]);
+    switch (schemaResponse.type) {
+      case "array":
+        return this.generateArray(schemaResponse);
 
-		if(schemaResponse.anyOf)
-			return this.generate(schemaResponse.anyOf[0]);
+      case "object":
+        return this.generateObject(schemaResponse);
 
-		const fakerExtension = schemaResponse['x-faker'];
-		if(fakerExtension) {
-			try {
-				return this.generateByFaker(fakerExtension);
-			} catch(e) {
-				logger.warn(`Failed to generate fake result using ${fakerExtension} schema. Falling back to primitive type.`);
-			}
-		}
+      case "string":
+        return this.generateString(schemaResponse);
 
-		switch(schemaResponse.type) {
+      case "number":
+        return this.generateNumber(schemaResponse);
 
-			case 'array':
-				return this.generateArray(schemaResponse);
+      case "integer":
+        return this.generateInteger(schemaResponse);
 
-			case 'object':
-				return this.generateObject(schemaResponse);
+      case "boolean":
+        return this.generateBoolean(schemaResponse);
 
-			case 'string':
-				return this.generateString(schemaResponse);
+      default:
+        throw new Error("Could not generate response: unknown type");
+    }
+  }
 
-			case 'number':
-				return this.generateNumber(schemaResponse);
+  static generateByFaker(fakerString) {
+    const fakerRegex = /^(?<namespace>\w+)\.(?<method>\w+)(?:\((?<argsString>.*)\))?$/.exec(
+      fakerString
+    );
+    if (!fakerRegex)
+      throw new Error(
+        "Faker extension method is not in the right format. Expecting <namespace>.<method>(<args>) format."
+      );
 
-			case 'integer':
-				return this.generateInteger(schemaResponse);
+    const { namespace, method, argsString } = fakerRegex.groups;
+    if (!namespace in faker)
+      throw new Error(
+        `Invalid faker namespace used. Must be one of ${Object.keys(faker).join(
+          ","
+        )}`
+      );
+    if (!method in faker[namespace])
+      throw new Error(
+        `Method '${method}' not found in faker namespace '${namespace}'. Must be one of ${Object.keys(
+          faker[namespace]
+        ).join(",")}`
+      );
 
-			case 'boolean':
-				return this.generateBoolean(schemaResponse);
+    const args = argsString ? JSON.parse(`[${argsString}]`) : [];
 
-			default:
-				throw new Error('Could not generate response: unknown type');
-		}
-	}
+    return faker[namespace][method](...args);
+  }
 
-	static generateByFaker(fakerString) {
-		// If a date function is used, we want to call the method directly to be able to get the Date object back
-		const dateMatch = /^date\.(.+)/.exec(fakerString);
-		if(dateMatch) {
-			const method = dateMatch[1];
-			const date = faker.date[method]();
-			return date.toISOString();
-		}
+  static generateArray(schema) {
+    let count = Number(schema["x-count"]);
+    if (Number.isNaN(count) || count < 1) count = 1;
 
-		return faker.fake(`{{${fakerString}}}`);
-	}
+    return [...new Array(count).keys()].map(() => this.generate(schema.items));
+  }
 
-	static generateArray(schema) {
-		let count = Number(schema['x-count']);
-		if(Number.isNaN(count) || count < 1)
-			count = 1;
+  static generateObject(schema) {
+    const properties = schema.properties || {};
 
-		return [...new Array(count).keys()].map(() => this.generate(schema.items));
-	}
+    return Object.entries(properties)
+      .map(([property, propertySchema]) => [
+        property,
+        this.generate(propertySchema),
+      ])
+      .reduce(
+        (acum, [property, value]) => ({
+          ...acum,
+          [property]: value,
+        }),
+        {}
+      );
+  }
 
-	static generateObject(schema) {
+  static generateString() {
+    return "string";
+  }
 
-		const properties = schema.properties || {};
+  static generateNumber() {
+    return 1;
+  }
 
-		return Object.entries(properties)
-			.map(([property, propertySchema]) => ([property, this.generate(propertySchema)]))
-			.reduce((acum, [property, value]) => ({
-				...acum,
-				[property]: value
-			}), {});
-	}
+  static generateInteger() {
+    return 1;
+  }
 
-	static generateString() {
-		return 'string';
-	}
-
-	static generateNumber() {
-		return 1;
-	}
-
-	static generateInteger() {
-		return 1;
-	}
-
-	static generateBoolean() {
-		return true;
-	}
-
+  static generateBoolean() {
+    return true;
+  }
 }
 
 module.exports = ResponseGenerator;

--- a/package-lock.json
+++ b/package-lock.json
@@ -708,6 +708,7 @@
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
+        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -1433,6 +1434,11 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
+    "faker": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-5.4.0.tgz",
+      "integrity": "sha512-Y9n/Ky/xZx/Bj8DePvXspUYRtHl/rGQytoIT5LaxmNwSe3wWyOeOXb3lT6Dpipq240PVpeFaGKzScz/5fvff2g=="
+    },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -1522,7 +1528,16 @@
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dev": true,
       "requires": {
-        "locate-path": "^5.0.0"
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        }
       }
     },
     "flat": {
@@ -1656,6 +1671,12 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2576,6 +2576,11 @@
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
+    "micro-memoize": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/micro-memoize/-/micro-memoize-4.0.9.tgz",
+      "integrity": "sha512-Z2uZi/IUMGQDCXASdujXRqrXXEwSY0XffUrAOllhqzQI3wpUyZbiZTiE2JuYC0HSG2G7DbCS5jZmsEKEGZuemg=="
+    },
     "mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
     "express": "^4.17.1",
+    "faker": "^5.4.0",
     "js-yaml": "^4.0.0",
     "json-refs": "^3.0.15",
     "lllog": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "js-yaml": "^4.0.0",
     "json-refs": "^3.0.15",
     "lllog": "^1.1.2",
+    "micro-memoize": "^4.0.9",
     "parse-prefer-header": "^1.0.0",
     "superstruct": "~0.6.1",
     "yargs": "^16.2.0"

--- a/tests/response-generator/index.js
+++ b/tests/response-generator/index.js
@@ -206,6 +206,21 @@ describe('Response Generator', () => {
 			assert.strictEqual(response[0], response[0] | 1);
 		});
 
+		it('Should return an array with specified number of items if type is defined as array and x-count extension is specified', () => {
+
+			const responseSchema = {
+				type: 'array',
+				'x-count': 2,
+				items: {
+					type: 'integer'
+				}
+			};
+
+			const response = ResponseGenerator.generate(responseSchema);
+
+			assert.deepStrictEqual(response, [1, 1]);
+		});
+
 		it('Should return an empty object if type is defined as object without any other props', () => {
 
 			const responseSchema = {

--- a/tests/response-generator/index.js
+++ b/tests/response-generator/index.js
@@ -12,7 +12,9 @@ describe('Response Generator', () => {
 	});
 
 	describe('Generate', () => {
-		it("Should return the example if it's defined", () => {
+
+		it('Should return the example if it\'s defined', () => {
+
 			const responseSchema = {
 				example: {
 					foo: 'bar'
@@ -27,6 +29,7 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return the first example if examples is defined', () => {
+
 			const responseSchema = {
 				examples: {
 					first: {
@@ -45,6 +48,7 @@ describe('Response Generator', () => {
 		});
 
 		it('Should throw if examples is defined but example has no value', () => {
+
 			const responseSchema = {
 				examples: {
 					first: {
@@ -56,7 +60,9 @@ describe('Response Generator', () => {
 			assert.throws(() => ResponseGenerator.generate(responseSchema));
 		});
 
+
 		it('Should return the first example if examples is defined & preferred example value undefined', () => {
+
 			const responseSchema = {
 				examples: {
 					first: {
@@ -78,6 +84,7 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return the preferred example if prefer header is set', () => {
+
 			const responseSchema = {
 				examples: {
 					cat: {
@@ -91,7 +98,7 @@ describe('Response Generator', () => {
 						}
 					},
 					dog: {
-						summary: "An example of a dog with a cat's name",
+						summary: 'An example of a dog with a cat\'s name',
 						value: {
 							name: 'Puma',
 							petType: 'Dog',
@@ -114,7 +121,8 @@ describe('Response Generator', () => {
 			});
 		});
 
-		it("Should return the schema's example if it's defined", () => {
+		it('Should return the schema\'s example if it\'s defined', () => {
+
 			const responseSchema = {
 				schema: {
 					example: {
@@ -130,14 +138,13 @@ describe('Response Generator', () => {
 			});
 		});
 
-		it("Should return the schema's first example if examples is defined", () => {
+		it('Should return the schema\'s first example if examples is defined', () => {
+
 			const responseSchema = {
 				schema: {
-					examples: [
-						{
-							foo: 'bar'
-						}
-					]
+					examples: [{
+						foo: 'bar'
+					}]
 				}
 			};
 
@@ -149,6 +156,7 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return the first enum element if enum is defined', () => {
+
 			const responseSchema = {
 				enum: ['foo', 'bar', 'baz']
 			};
@@ -159,6 +167,7 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return a number if type is defined as number', () => {
+
 			const responseSchema = {
 				type: 'number'
 			};
@@ -169,6 +178,7 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return an integer if type is defined as integer', () => {
+
 			const responseSchema = {
 				type: 'integer'
 			};
@@ -180,6 +190,7 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return a not-empty array if type is defined as array', () => {
+
 			const responseSchema = {
 				type: 'array',
 				items: {
@@ -195,6 +206,7 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return an array with specified number of items if type is defined as array and x-count extension is specified', () => {
+
 			const responseSchema = {
 				type: 'array',
 				'x-count': 2,
@@ -209,6 +221,7 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return an empty object if type is defined as object without any other props', () => {
+
 			const responseSchema = {
 				type: 'object'
 			};
@@ -219,6 +232,7 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return the schema example if type is defined as object with an example property', () => {
+
 			const responseSchema = {
 				type: 'object',
 				example: { foo: 'bar' }
@@ -230,6 +244,7 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return all schemas merged if the allOf property is defiend', () => {
+
 			const responseSchema = {
 				schema: {
 					allOf: [
@@ -254,6 +269,7 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return the first schema if the oneOf property is defiend', () => {
+
 			const responseSchema = {
 				schema: {
 					oneOf: [
@@ -277,6 +293,7 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return the first schema if the anyOf property is defiend', () => {
+
 			const responseSchema = {
 				schema: {
 					anyOf: [
@@ -300,6 +317,7 @@ describe('Response Generator', () => {
 		});
 
 		it('Should throw if an invalid type is defined', () => {
+
 			const responseSchema = {
 				type: 'invalidType'
 			};
@@ -308,12 +326,14 @@ describe('Response Generator', () => {
 		});
 
 		it('Should throw if an invalid schema is passed', () => {
+
 			const responseSchema = {};
 
 			assert.throws(() => ResponseGenerator.generate(responseSchema));
 		});
 
 		it('Should return a generated response if a complex schema is defined', () => {
+
 			const responseSchema = {
 				schema: {
 					type: 'object',
@@ -397,8 +417,7 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return a generated response with value generated using relevant faker method if x-faker extension is ' +
-        'present in and method exists in faker',
-		() => {
+			'present in and method exists in faker', () => {
 			sinon.replace(faker.name, 'firstName', sinon.fake.returns('bob'));
 			const responseSchema = {
 				type: 'string',
@@ -411,11 +430,7 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return a generated response with date in ISO format if type is date and x-faker is used', () => {
-			sinon.replace(
-				faker.date,
-				'recent',
-				sinon.fake.returns(new Date(2000, 0, 1))
-			);
+			sinon.replace(faker.date, 'recent', sinon.fake.returns(new Date(2000, 0, 1)));
 			const responseSchema = {
 				type: 'date-time',
 				'x-faker': 'date.recent'
@@ -427,8 +442,7 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return a generated response with standard primitive value if x-faker field is ' +
-        'present but method does not exist in faker',
-		() => {
+			'present but method does not exist in faker', () => {
 			const responseSchema = {
 				type: 'string',
 				'x-faker': 'idonotexist'

--- a/tests/response-generator/index.js
+++ b/tests/response-generator/index.js
@@ -6,7 +6,6 @@ const sinon = require('sinon');
 
 const ResponseGenerator = require('../../lib/response-generator');
 
-
 describe('Response Generator', () => {
 	beforeEach(() => {
 		sinon.restore();

--- a/tests/response-generator/index.js
+++ b/tests/response-generator/index.js
@@ -402,12 +402,12 @@ describe('Response Generator', () => {
 			});
 		});
 
-		it('Should return a generated response with value generated using relevant faker method if X-Faker field is ' +
-			'present in and exists in faker', () => {
+		it('Should return a generated response with value generated using relevant faker method if x-faker extension is ' +
+			'present in and method exists in faker', () => {
 			sinon.replace(faker.name, 'firstName', sinon.fake.returns('bob'));
 			const responseSchema = {
 				type: 'string',
-				'X-Faker': 'name.firstName'
+				'x-faker': 'name.firstName'
 			};
 
 			const response = ResponseGenerator.generate(responseSchema);
@@ -415,11 +415,11 @@ describe('Response Generator', () => {
 			assert.strictEqual(response, 'bob');
 		});
 
-		it('Should return a generated response with standard primitive value if X-Faker field is ' +
+		it('Should return a generated response with standard primitive value if x-faker field is ' +
 			'present but method does not exist in faker', () => {
 			const responseSchema = {
 				type: 'string',
-				'X-Faker': 'idonotexist'
+				'x-faker': 'idonotexist'
 			};
 
 			const response = ResponseGenerator.generate(responseSchema);

--- a/tests/response-generator/index.js
+++ b/tests/response-generator/index.js
@@ -430,6 +430,18 @@ describe('Response Generator', () => {
 			assert.strictEqual(response, 'bob');
 		});
 
+		it('Should return a generated response with date in ISO format if type is date and x-faker is used', () => {
+			sinon.replace(faker.date, 'recent', sinon.fake.returns(new Date(2000, 0, 1)));
+			const responseSchema = {
+				type: 'date-time',
+				'x-faker': 'date.recent'
+			};
+
+			const response = ResponseGenerator.generate(responseSchema);
+
+			assert.strictEqual(response, '2000-01-01T00:00:00.000Z');
+		});
+
 		it('Should return a generated response with standard primitive value if x-faker field is ' +
 			'present but method does not exist in faker', () => {
 			const responseSchema = {

--- a/tests/response-generator/index.js
+++ b/tests/response-generator/index.js
@@ -1,10 +1,16 @@
 'use strict';
 
 const assert = require('assert');
+const faker = require('faker');
+const sinon = require('sinon');
 
 const ResponseGenerator = require('../../lib/response-generator');
 
+
 describe('Response Generator', () => {
+	beforeEach(() => {
+		sinon.restore();
+	});
 
 	describe('Generate', () => {
 
@@ -394,6 +400,31 @@ describe('Response Generator', () => {
 					employeeId: '0001222-B'
 				}
 			});
+		});
+
+		it('Should return a generated response with value generated using relevant faker method if X-Faker field is ' +
+			'present in and exists in faker', () => {
+			sinon.replace(faker.name, 'firstName', sinon.fake.returns('bob'));
+			const responseSchema = {
+				type: 'string',
+				'X-Faker': 'name.firstName'
+			};
+
+			const response = ResponseGenerator.generate(responseSchema);
+
+			assert.strictEqual(response, 'bob');
+		});
+
+		it('Should return a generated response with standard primitive value if X-Faker field is ' +
+			'present but method does not exist in faker', () => {
+			const responseSchema = {
+				type: 'string',
+				'X-Faker': 'idonotexist'
+			};
+
+			const response = ResponseGenerator.generate(responseSchema);
+
+			assert.strictEqual(response, 'string');
 		});
 
 	});

--- a/tests/response-generator/index.js
+++ b/tests/response-generator/index.js
@@ -438,7 +438,7 @@ describe('Response Generator', () => {
 
 			const response = ResponseGenerator.generate(responseSchema);
 
-			assert.strictEqual(response, '2000-01-01T00:00:00.000Z');
+			assert.strictEqual(response.toISOString(), '2000-01-01T00:00:00.000Z');
 		});
 
 		it('Should return a generated response with standard primitive value if x-faker field is ' +

--- a/tests/response-generator/index.js
+++ b/tests/response-generator/index.js
@@ -418,7 +418,7 @@ describe('Response Generator', () => {
 
 		it('Should return a generated response with value generated using relevant faker method if x-faker extension is ' +
 			'present in and method exists in faker', () => {
-			sinon.replace(faker.name, 'firstName', sinon.fake.returns('bob'));
+			sinon.stub(faker.name, 'firstName').returns('bob');
 			const responseSchema = {
 				type: 'string',
 				'x-faker': 'name.firstName'
@@ -430,7 +430,7 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return a generated response with date in ISO format if type is date and x-faker is used', () => {
-			sinon.replace(faker.date, 'recent', sinon.fake.returns(new Date(2000, 0, 1)));
+			sinon.stub(faker.date, 'recent').returns(new Date(2000, 0, 1));
 			const responseSchema = {
 				type: 'date-time',
 				'x-faker': 'date.recent'

--- a/tests/response-generator/index.js
+++ b/tests/response-generator/index.js
@@ -12,9 +12,7 @@ describe('Response Generator', () => {
 	});
 
 	describe('Generate', () => {
-
-		it('Should return the example if it\'s defined', () => {
-
+		it("Should return the example if it's defined", () => {
 			const responseSchema = {
 				example: {
 					foo: 'bar'
@@ -29,7 +27,6 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return the first example if examples is defined', () => {
-
 			const responseSchema = {
 				examples: {
 					first: {
@@ -48,7 +45,6 @@ describe('Response Generator', () => {
 		});
 
 		it('Should throw if examples is defined but example has no value', () => {
-
 			const responseSchema = {
 				examples: {
 					first: {
@@ -60,9 +56,7 @@ describe('Response Generator', () => {
 			assert.throws(() => ResponseGenerator.generate(responseSchema));
 		});
 
-
 		it('Should return the first example if examples is defined & preferred example value undefined', () => {
-
 			const responseSchema = {
 				examples: {
 					first: {
@@ -84,7 +78,6 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return the preferred example if prefer header is set', () => {
-
 			const responseSchema = {
 				examples: {
 					cat: {
@@ -98,7 +91,7 @@ describe('Response Generator', () => {
 						}
 					},
 					dog: {
-						summary: 'An example of a dog with a cat\'s name',
+						summary: "An example of a dog with a cat's name",
 						value: {
 							name: 'Puma',
 							petType: 'Dog',
@@ -121,8 +114,7 @@ describe('Response Generator', () => {
 			});
 		});
 
-		it('Should return the schema\'s example if it\'s defined', () => {
-
+		it("Should return the schema's example if it's defined", () => {
 			const responseSchema = {
 				schema: {
 					example: {
@@ -138,13 +130,14 @@ describe('Response Generator', () => {
 			});
 		});
 
-		it('Should return the schema\'s first example if examples is defined', () => {
-
+		it("Should return the schema's first example if examples is defined", () => {
 			const responseSchema = {
 				schema: {
-					examples: [{
-						foo: 'bar'
-					}]
+					examples: [
+						{
+							foo: 'bar'
+						}
+					]
 				}
 			};
 
@@ -156,7 +149,6 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return the first enum element if enum is defined', () => {
-
 			const responseSchema = {
 				enum: ['foo', 'bar', 'baz']
 			};
@@ -167,7 +159,6 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return a number if type is defined as number', () => {
-
 			const responseSchema = {
 				type: 'number'
 			};
@@ -178,7 +169,6 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return an integer if type is defined as integer', () => {
-
 			const responseSchema = {
 				type: 'integer'
 			};
@@ -190,7 +180,6 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return a not-empty array if type is defined as array', () => {
-
 			const responseSchema = {
 				type: 'array',
 				items: {
@@ -206,7 +195,6 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return an array with specified number of items if type is defined as array and x-count extension is specified', () => {
-
 			const responseSchema = {
 				type: 'array',
 				'x-count': 2,
@@ -221,7 +209,6 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return an empty object if type is defined as object without any other props', () => {
-
 			const responseSchema = {
 				type: 'object'
 			};
@@ -232,7 +219,6 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return the schema example if type is defined as object with an example property', () => {
-
 			const responseSchema = {
 				type: 'object',
 				example: { foo: 'bar' }
@@ -244,7 +230,6 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return all schemas merged if the allOf property is defiend', () => {
-
 			const responseSchema = {
 				schema: {
 					allOf: [
@@ -269,7 +254,6 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return the first schema if the oneOf property is defiend', () => {
-
 			const responseSchema = {
 				schema: {
 					oneOf: [
@@ -293,7 +277,6 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return the first schema if the anyOf property is defiend', () => {
-
 			const responseSchema = {
 				schema: {
 					anyOf: [
@@ -317,7 +300,6 @@ describe('Response Generator', () => {
 		});
 
 		it('Should throw if an invalid type is defined', () => {
-
 			const responseSchema = {
 				type: 'invalidType'
 			};
@@ -326,14 +308,12 @@ describe('Response Generator', () => {
 		});
 
 		it('Should throw if an invalid schema is passed', () => {
-
 			const responseSchema = {};
 
 			assert.throws(() => ResponseGenerator.generate(responseSchema));
 		});
 
 		it('Should return a generated response if a complex schema is defined', () => {
-
 			const responseSchema = {
 				schema: {
 					type: 'object',
@@ -417,7 +397,8 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return a generated response with value generated using relevant faker method if x-faker extension is ' +
-			'present in and method exists in faker', () => {
+        'present in and method exists in faker',
+		() => {
 			sinon.replace(faker.name, 'firstName', sinon.fake.returns('bob'));
 			const responseSchema = {
 				type: 'string',
@@ -430,7 +411,11 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return a generated response with date in ISO format if type is date and x-faker is used', () => {
-			sinon.replace(faker.date, 'recent', sinon.fake.returns(new Date(2000, 0, 1)));
+			sinon.replace(
+				faker.date,
+				'recent',
+				sinon.fake.returns(new Date(2000, 0, 1))
+			);
 			const responseSchema = {
 				type: 'date-time',
 				'x-faker': 'date.recent'
@@ -442,7 +427,8 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return a generated response with standard primitive value if x-faker field is ' +
-			'present but method does not exist in faker', () => {
+        'present but method does not exist in faker',
+		() => {
 			const responseSchema = {
 				type: 'string',
 				'x-faker': 'idonotexist'
@@ -453,6 +439,68 @@ describe('Response Generator', () => {
 			assert.strictEqual(response, 'string');
 		});
 
-	});
+		it('Should return a generated response with string value built using composite faker methods if ' +
+        'x-faker extension includes mustache template string',
+		() => {
+			sinon
+				.stub(faker.random, 'number')
+				.onFirstCall()
+				.returns(1)
+				.onSecondCall()
+				.returns(2);
+			const responseSchema = {
+				type: 'string',
+				'x-faker': '{{random.number}}+{{random.number}}'
+			};
 
+			const response = ResponseGenerator.generate(responseSchema);
+
+			assert.strictEqual(response, '1+2');
+		});
+
+		it('Should return a generated response with standard primitive value if x-faker field is not in the namespace.method format', () => {
+			const responseSchema = {
+				type: 'string',
+				'x-faker': 'random'
+			};
+
+			const response = ResponseGenerator.generate(responseSchema);
+
+			assert.strictEqual(response, 'string');
+		});
+
+		it('Should return a generated response with standard primitive value if x-faker field contains an invalid faker namespace', () => {
+			const responseSchema = {
+				type: 'string',
+				'x-faker': 'randum.number'
+			};
+
+			const response = ResponseGenerator.generate(responseSchema);
+
+			assert.strictEqual(response, 'string');
+		});
+
+		it('Should return a generated response with standard primitive value if x-faker field contains an invalid faker method', () => {
+			const responseSchema = {
+				type: 'string',
+				'x-faker': 'random.numbr'
+			};
+
+			const response = ResponseGenerator.generate(responseSchema);
+
+			assert.strictEqual(response, 'string');
+		});
+
+		it('Should return a generated response with value from faker when x-faker extension contains valid faker namespace, method and arguments', () => {
+			sinon.stub(faker.random, 'number').returns(1);
+			const responseSchema = {
+				type: 'integer',
+				'x-faker': 'random.number({ "max": 5 })'
+			};
+
+			const response = ResponseGenerator.generate(responseSchema);
+
+			assert.strictEqual(response, 1);
+		});
+	});
 });


### PR DESCRIPTION
To match similar products, support has been added to allow an `x-faker` extension to be used in an OpenAPI definition. The value of the `x-faker` extension will be used during response generation by running the given faker method.
To ensure that multiple calls to the endpoint return the same result, responses are cached in memory based on the url, query parameters, body and use of the Prefers header.

Handling of an additional `x-count` extension method has also been added so that more than one result can be returned from a generated array.

Faker has been configured to produce results based on the locale of the running server. This could likely be extended to allow a custom locale to be set either through a new extension on the OpenAPI documentation or a CLI argument/constructor parameter.