### PR TITLE
Add a "quiet" option to suppress output

### DIFF
--- a/lib/open-api-mocker-cli.js
+++ b/lib/open-api-mocker-cli.js
@@ -37,23 +37,20 @@ const { argv } = require('yargs')
 	.option('verbose', {
 		type: 'boolean',
 		alias: 'v',
-		default: false
+		default: false,
+		conflicts: 'quiet'
 	})
 	.option('quiet', {
 		type: 'boolean',
 		alias: 'q',
 		description: 'Suppress request output, only show errors',
-		default: false
+		default: false,
+		conflicts: 'verbose'
 	})
 	.demandOption('schema')
 	.help();
 
 const logger = require('lllog')();
-
-if(argv.verbose && argv.quiet) {
-	logger.fatal("Can't specify both --quiet and --verbose");
-	process.exit(CLI_ERRORS.RUNTIME_ERROR);
-}
 
 if(argv.verbose)
 	logger.setMinLevel('debug');

--- a/lib/open-api-mocker-cli.js
+++ b/lib/open-api-mocker-cli.js
@@ -39,13 +39,27 @@ const { argv } = require('yargs')
 		alias: 'v',
 		default: false
 	})
+	.option('quiet', {
+		type: 'boolean',
+		alias: 'q',
+		description: 'Suppress request output, only show errors',
+		default: false
+	})
 	.demandOption('schema')
 	.help();
 
 const logger = require('lllog')();
 
+if(argv.verbose && argv.quiet) {
+	logger.fatal("Can't specify both --quiet and --verbose");
+	process.exit(CLI_ERRORS.RUNTIME_ERROR);
+}
+
 if(argv.verbose)
 	logger.setMinLevel('debug');
+else if(argv.quiet)
+	logger.setMinLevel('error');
+
 
 const OpenApiMocker = require('./open-api-mocker');
 


### PR DESCRIPTION
I'm using `open-api-mocker` in a docker compose workflow (it's working great so far) and I'm finding the output from both requests and responses quite verbose. Would it be possible to add a `--quiet` flag to suppress output and only log errors?