### PR TITLE
#22 allow custom server injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,29 @@ Will produce the following response:
 ]
 ```
 
+## Extending OpenAPI Mocker
+OpenAPI Mocker is open for extension through the use of custom server implementations.  
+A custom server instance can be passed to the constructor of `OpenApiMocker` which is expecting an object that 
+implements the following interface:
+```ts
+interface IOpenApiServer {
+    setServers(serverBlockFromSchema: any): IOpenApiServer;
+    setPort(port: number): IOpenApiServer;
+    setPaths(pathsFromSchema: any): IOpenApiServer;
+    init(): Promise<void>;
+    shutdown(): Promise<void>;
+}
+```
+
+This is then injected in to the `OpenApiMocker` constructor:
+```ts
+const server = new MyCustonServer();
+const mocker = new OpenApiMocker({ server });
+mocker.setSchema(schema);
+await mocker.validate();
+await mocker.mock();
+``` 
+
 ## Tests
 
 Simply run `npm t`

--- a/lib/open-api-mocker.js
+++ b/lib/open-api-mocker.js
@@ -12,11 +12,15 @@ class OpenApiMocker {
 		return 5000;
 	}
 
-	constructor({ port, server = 'express' }) {
-		// eslint-disable-next-line global-require, import/no-dynamic-require
-		const Server = require(`./mocker/${server}/server`);
+	constructor({ port, server }) {
+		// Legacy handling of string based server that loads a server implementation based on folder name
+		if(typeof server === 'string' || server == null) {
+			// eslint-disable-next-line global-require, import/no-dynamic-require
+			const Server = require(`./mocker/${server || 'express'}/server`);
+			server = new Server();
+		}
 
-		this.server = new Server();
+		this.server = server;
 		this.port = port || this.constructor.defaultPort;
 	}
 

--- a/tests/open-api-mocker.js
+++ b/tests/open-api-mocker.js
@@ -19,6 +19,7 @@ describe('Openapi', () => {
 			sandbox.spy(Server.prototype, 'setPort');
 			sandbox.spy(Server.prototype, 'setPaths');
 			sandbox.stub(Server.prototype, 'init');
+			sandbox.stub(Server.prototype, 'shutdown');
 		});
 
 		afterEach(() => {
@@ -37,6 +38,34 @@ describe('Openapi', () => {
 			sandbox.assert.calledOnce(Server.prototype.setPort);
 			sandbox.assert.calledOnce(Server.prototype.setPaths);
 			sandbox.assert.calledOnce(Server.prototype.init);
+		});
+
+		it('Should set the parameters of a passed in server instance', async () => {
+			const server = {
+				setServers: sandbox.stub().returnsThis(),
+				setPort: sandbox.stub().returnsThis(),
+				setPaths: sandbox.stub().returnsThis(),
+				init: sandbox.stub().resolves()
+			};
+
+			const openApiMocker = new OpenApiMocker({ server });
+			openApiMocker.setSchema(schema);
+
+			await openApiMocker.validate();
+			await openApiMocker.mock();
+
+			sandbox.assert.calledOnce(server.setServers);
+			sandbox.assert.calledOnce(server.setPort);
+			sandbox.assert.calledOnce(server.setPaths);
+			sandbox.assert.calledOnce(server.init);
+		});
+
+		it('should shutdown the server when shutdown is called', async () => {
+			const openApiMocker = new OpenApiMocker({});
+
+			await openApiMocker.shutdown();
+
+			sandbox.assert.calledOnce(Server.prototype.shutdown);
 		});
 
 	});


### PR DESCRIPTION
This PR changes the way that the Server is initialised to better allow custom servers to be injected.
An object that implements the following interface can be injected in the constructor:
```ts
interface IOpenApiServer {
    setServers(serverBlockFromSchema: any): IOpenApiServer;
    setPort(port: number): IOpenApiServer;
    setPaths(pathsFromSchema: any): IOpenApiServer;
    init(): Promise<void>;
    shutdown(): Promise<void>;
}
```