### PR TITLE
Support empty response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Support empty response.
 - `quiet` (alias `q`) option to avoid printing every request and response
 
 ### Fixed

--- a/lib/response-generator/index.js
+++ b/lib/response-generator/index.js
@@ -8,6 +8,9 @@ faker.setLocale(locale.replace('-', '_'));
 
 class ResponseGenerator {
 	static generate(schemaResponse, preferredExampleName) {
+		if(Object.keys(schemaResponse).length === 0)
+			return null;
+
 		if(schemaResponse.example)
 			return schemaResponse.example;
 

--- a/tests/response-generator/index.js
+++ b/tests/response-generator/index.js
@@ -316,6 +316,15 @@ describe('Response Generator', () => {
 			});
 		});
 
+		it('Should return empty response in case of empty response schema', () => {
+
+			const responseSchema = {};
+
+			const response = ResponseGenerator.generate(responseSchema);
+
+			assert.deepStrictEqual(response, null);
+		});
+
 		it('Should throw if an invalid type is defined', () => {
 
 			const responseSchema = {
@@ -327,7 +336,7 @@ describe('Response Generator', () => {
 
 		it('Should throw if an invalid schema is passed', () => {
 
-			const responseSchema = {};
+			const responseSchema = { abc: 'xyz' };
 
 			assert.throws(() => ResponseGenerator.generate(responseSchema));
 		});


### PR DESCRIPTION
As OpenAPI Specification allows empty responses (https://swagger.io/docs/specification/describing-responses/), we should support this. Currently OpenAPI Mocker considers empty response content invalid.