### PR TITLE
Fix/schema pattern type validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Response header `x-powered-by` has now the correct value
+- Schema Object `pattern` property can be passed as a string
 
 ## [1.7.0] - 2021-04-20
 ### Added

--- a/lib/components/schemas/structs.js
+++ b/lib/components/schemas/structs.js
@@ -16,7 +16,7 @@ const SchemaStruct = struct.intersection([
 		exclusiveMinimum: 'boolean?',
 		maxLength: 'number?',
 		minLength: 'number?',
-		pattern: 'regexp?',
+		pattern: 'string|regexp?',
 		maxItems: 'number?',
 		minItems: 'number?',
 		uniqueItems: 'boolean?',


### PR DESCRIPTION
`pattern` property can be passed a string-regexp since regexp are not a valid type in JSON files