### PR TITLE
Increase json body limit to 10mb

### DIFF
--- a/lib/mocker/express/server.js
+++ b/lib/mocker/express/server.js
@@ -57,7 +57,7 @@ class Server {
 				origin: true,
 				credentials: true
 			}),
-			bodyParser.json(),
+			bodyParser.json({ limit: '10mb' }),
 			bodyParser.urlencoded({ limit: '50mb', extended: false, parameterLimit: 50000 }),
 			bodyParser.text(),
 			bodyParser.raw()


### PR DESCRIPTION
Based on my experience when making JSON requests to mock API around 400K in size returns error 413 Payload Too Large. Increasing the limit seems to have fixed the problem.