### PR TITLE
Response selection using request cookie

### DIFF
--- a/lib/mocker/express/request-handler.js
+++ b/lib/mocker/express/request-handler.js
@@ -52,7 +52,7 @@ const handleRequest = (path, responseHandler) => (req, res) => {
 	if(failedValidations.length)
 		return responseHandler(req, res, { errors: failedValidations }, 400);
 
-	const preferHeader = req.header('prefer') || '';
+	const preferHeader = req.header('prefer') || req.header('cookie') || '';
 
 	const { statusCode, headers: responseHeaders, body } =
 			getResponseMemo(path, req.path, JSON.stringify(req.query), preferHeader, JSON.stringify(requestBody));


### PR DESCRIPTION
In addition to the existing Prefer header functionality, I added the same but with a cookie.
Prefer header has greater priority over cookie