### PR TITLE
fixed bug setting of faker locale on languages same as country

### DIFF
--- a/lib/utils/get-faker-locale.js
+++ b/lib/utils/get-faker-locale.js
@@ -4,7 +4,7 @@ const getFakerLocale = () => {
 	const { locale } = Intl.DateTimeFormat().resolvedOptions();
 	const [lang, country = ''] = locale.split('-');
 
-	return (lang.toLowerCase() === country.toLowerCase() && lang.toLowerCase()) === 'pt' ? lang : `${lang}_${country}`;
+	return (lang.toLowerCase() === country.toLowerCase()) ? lang : `${lang}_${country}`;
 };
 
 module.exports = getFakerLocale;

--- a/lib/utils/get-faker-locale.js
+++ b/lib/utils/get-faker-locale.js
@@ -4,7 +4,10 @@ const getFakerLocale = () => {
 	const { locale } = Intl.DateTimeFormat().resolvedOptions();
 	const [lang, country = ''] = locale.split('-');
 
-	return (lang.toLowerCase() === country.toLowerCase()) ? lang : `${lang}_${country}`;
+	return lang.toLowerCase() === country.toLowerCase() &&
+		lang.toLowerCase() !== 'pt'
+		? lang
+		: `${lang}_${country}`;
 };
 
 module.exports = getFakerLocale;


### PR DESCRIPTION
I tried to run open-api-mocker with a locale for faker to get dutch texts with locale `nl-NL` but your code turned this into `nl_NL` while it should be only `nl` looking at what faker expects.

There was also a weird part with portugese in the if statement that didn't make sense. This fix should make everything work again.