### PR TITLE
Added preferring x-faker expression over example if present.

### DIFF
--- a/lib/response-generator/index.js
+++ b/lib/response-generator/index.js
@@ -10,7 +10,8 @@ class ResponseGenerator {
 
 	static generate(schemaResponse, preferredExampleName) {
 
-		if(typeof schemaResponse.example !== 'undefined' || (schemaResponse.examples && Object.values(schemaResponse.examples).length)) {
+		if((typeof schemaResponse.example !== 'undefined' && !schemaResponse['x-faker']) ||
+			(schemaResponse.examples && Object.values(schemaResponse.examples).length)) {
 			const bestExample = this.getBestExample(schemaResponse, preferredExampleName);
 			if(bestExample !== undefined)
 				return bestExample;


### PR DESCRIPTION
This change adds a check if a property has the `x-faker` extension.
If so it prefers generating a fake value over simply mapping an example value.
If no `x-faker` extension is present it falls back to the default example generation.

Motivation of this change is: Having changing data is - at least in our team - considered more valuable during development against a mocked API than static data - for instance when testing web designs.

Keep up the good work! This project help us a lot at building our APIs.