### PR TITLE
Use faker when generating a random enum value

### DIFF
--- a/lib/response-generator/index.js
+++ b/lib/response-generator/index.js
@@ -33,8 +33,7 @@ class ResponseGenerator {
 	}
 
 	static generateByEnum(enumOptions) {
-		const randomIndex = Math.floor(Math.random() * enumOptions.length);
-		return enumOptions[randomIndex];
+		return faker.random.arrayElement(enumOptions);
 	}
 
 	static generateBySchema(schemaResponse) {


### PR DESCRIPTION
I have made this change that replaces the use of Math.random with use of a specific faker method for grabbing a random array element.

My reasoning for this is to standardize where all random data is coming from.
I am using my own custom server implementation injected in the OpenApiMocker constructor to be able to fit this into a serverless architecture.
Since the server is custom, it does not run through the built in express request-handler and therefore skirts around the built in caching mechanism for responses (using micro-memoize).
I also need to modify this caching mechanism in my custom server since the serverless nature of requests mean that it cannot rely on a shared cache between calls. I have done this by creating a hash of the request url, body and query, taking the resulting byte array and using it as a seed value in faker. This results in the same random values coming out of faker for a request sent with the same data. However, due to this bit of code not running through faker, setting the faker seed has no effect and I will still receive a random enum value on each request.