### PR TITLE
Replace faker package with @faker-js/faker

### DIFF
--- a/lib/response-generator/index.js
+++ b/lib/response-generator/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const logger = require('lllog')();
-const faker = require('faker');
+const { faker } = require('@faker-js/faker');
 const getFakerLocale = require('../utils/get-faker-locale');
 
 faker.setLocale(getFakerLocale());
@@ -33,7 +33,7 @@ class ResponseGenerator {
 	}
 
 	static generateByEnum(enumOptions) {
-		return faker.random.arrayElement(enumOptions);
+		return faker.helpers.arrayElement(enumOptions);
 	}
 
 	static generateBySchema(schemaResponse) {

--- a/lib/utils/get-faker-locale.js
+++ b/lib/utils/get-faker-locale.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const faker = require('faker');
+const { faker } = require('@faker-js/faker');
 
 const DEFAULT_LOCALE = 'en';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.11.1",
       "license": "MIT",
       "dependencies": {
+        "@faker-js/faker": "^7.3.0",
         "ajv": "^6.12.6",
         "ajv-openapi": "^2.0.0",
         "body-parser": "^1.20.0",
@@ -17,7 +18,6 @@
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "express": "^4.18.1",
-        "faker": "^5.5.3",
         "js-yaml": "^4.1.0",
         "json-refs": "^3.0.15",
         "lllog": "^1.1.2",
@@ -430,6 +430,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.4.0.tgz",
+      "integrity": "sha512-xDd3Tvkt2jgkx1LkuwwxpNBy/Oe+LkZBTwkgEFTiWpVSZgQ5sc/LenbHKRHbFl0dq/KFeeq/szyyPtpJRKY0fg==",
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -2188,11 +2197,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "node_modules/faker": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
-      "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -6316,6 +6320,11 @@
         }
       }
     },
+    "@faker-js/faker": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.4.0.tgz",
+      "integrity": "sha512-xDd3Tvkt2jgkx1LkuwwxpNBy/Oe+LkZBTwkgEFTiWpVSZgQ5sc/LenbHKRHbFl0dq/KFeeq/szyyPtpJRKY0fg=="
+    },
     "@humanwhocodes/config-array": {
       "version": "0.10.4",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
@@ -7638,11 +7647,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "faker": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
-      "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g=="
     },
     "fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "sinon": "^14.0.0"
   },
   "dependencies": {
+    "@faker-js/faker": "^7.3.0",
     "ajv": "^6.12.6",
     "ajv-openapi": "^2.0.0",
     "body-parser": "^1.20.0",
@@ -46,7 +47,6 @@
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "express": "^4.18.1",
-    "faker": "^5.5.3",
     "js-yaml": "^4.1.0",
     "json-refs": "^3.0.15",
     "lllog": "^1.1.2",

--- a/tests/response-generator/index.js
+++ b/tests/response-generator/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const assert = require('assert');
-const faker = require('faker');
+const { faker } = require('@faker-js/faker');
 const sinon = require('sinon');
 
 const ResponseGenerator = require('../../lib/response-generator');
@@ -508,22 +508,22 @@ describe('Response Generator', () => {
         'x-faker extension includes mustache template string',
 		() => {
 			sinon
-				.stub(faker.random, 'number')
+				.stub(faker.datatype, 'number')
 				.onFirstCall()
 				.returns(1)
 				.onSecondCall()
 				.returns(2);
 			const responseSchema = {
 				type: 'string',
-				'x-faker': '{{random.number}}+{{random.number}}'
+				'x-faker': '{{datatype.number}}+{{datatype.number}}'
 			};
 
 			const response = ResponseGenerator.generate(responseSchema);
 
 			assert.strictEqual(response, '1+2');
-			sinon.assert.calledTwice(faker.random.number);
-			sinon.assert.calledWithExactly(faker.random.number.getCall(0));
-			sinon.assert.calledWithExactly(faker.random.number.getCall(1));
+			sinon.assert.calledTwice(faker.datatype.number);
+			sinon.assert.calledWithExactly(faker.datatype.number.getCall(0));
+			sinon.assert.calledWithExactly(faker.datatype.number.getCall(1));
 		});
 
 		it('Should return a generated response with standard primitive value if x-faker field is not in the namespace.method format', () => {
@@ -560,17 +560,17 @@ describe('Response Generator', () => {
 		});
 
 		it('Should return a generated response with value from faker when x-faker extension contains valid faker namespace, method and arguments', () => {
-			sinon.stub(faker.random, 'number').returns(1);
+			sinon.stub(faker.datatype, 'number').returns(1);
 			const responseSchema = {
 				type: 'integer',
-				'x-faker': 'random.number({ "max": 5 })'
+				'x-faker': 'datatype.number({ "max": 5 })'
 			};
 
 			const response = ResponseGenerator.generate(responseSchema);
 
 			assert.strictEqual(response, 1);
 
-			sinon.assert.calledOnceWithExactly(faker.random.number, { max: 5 });
+			sinon.assert.calledOnceWithExactly(faker.datatype.number, { max: 5 });
 		});
 	});
 });


### PR DESCRIPTION
Replaces the _faker_ package with _@faker-js/faker_.

NOTE: Due to some restructuring in the _@faker-js/faker_ package, this upgrade should be deemed a breaking change since schemas making use of deprecated APIs will no longer function (i.e. `x-faker: random.number` needs to be replaced with `x-faker: datatype.number`).

Fixes #62 