### PR TITLE
Attempt to find response example based on request body

### DIFF
--- a/lib/mocker/express/request-handler.js
+++ b/lib/mocker/express/request-handler.js
@@ -11,12 +11,15 @@ const colors = require('colors');
 // eslint-disable-next-line no-unused-vars
 const getResponse = (path, url, query, preferHeader, body) => {
 	const { example: preferredExampleName, statuscode: preferredStatusCode } = parsePreferHeader(preferHeader) || {};
+	const requestExampleName = path.findPreferredExampleByRequest(query, body);
 
 	if(preferredStatusCode)
 		logger.debug(`Searching requested response with status code ${preferredStatusCode}`);
+	else if(preferredExampleName)
+		logger.debug(`Searching requested response using example name ${preferredExampleName}`);
 	else
 		logger.debug('Searching first response');
-	return path.getResponse(preferredStatusCode, preferredExampleName);
+	return path.getResponse(preferredStatusCode, preferredExampleName || requestExampleName);
 };
 
 const getResponseMemo = memoize(getResponse, {

--- a/lib/paths/path.js
+++ b/lib/paths/path.js
@@ -246,6 +246,27 @@ class Path {
 		return responseHeaders;
 	}
 
+	findPreferredExampleByRequest(httpRequestBody) {
+
+		if(this.requestBody.content) {
+			let resultingExampleName;
+
+			Object.entries(this.requestBody.content).find(contentEntries => {
+				const requestContentTypeData = contentEntries[1];
+
+				return Object.entries(requestContentTypeData.examples).find(exampleEntries => {
+					const [exampleName, exampleData] = exampleEntries;
+					if(Object.entries(exampleData.value).toString() === Object.entries(httpRequestBody).toString())
+						resultingExampleName = exampleName;
+					return Object.entries(exampleData.value).toString() === Object.entries(httpRequestBody).toString();
+				});
+			});
+			return resultingExampleName;
+		}
+
+		return undefined;
+	}
+
 }
 
 module.exports = Path;

--- a/tests/paths/path.js
+++ b/tests/paths/path.js
@@ -2157,4 +2157,85 @@ describe('Paths', () => {
 		});
 	});
 
+	describe('Match request example to reponse example', () => {
+		it('Should return an example response if it matches an example request by name', () => {
+			const path = new Path({
+				uri: '/hello',
+				httpMethod: 'get',
+				parameters: undefined,
+				requestBody: {
+					required: true,
+					content: {
+						'application/json': {
+							examples: {
+								foo: { value: { name: 'Fred' } },
+								bar: { value: { name: 'Frank' } }
+							}
+						}
+					}
+				},
+				responses: {
+					200: {
+						description: 'OK',
+						content: {
+							'text/plain': {
+								examples: {
+									foo: 'Hello friend Fred',
+									bar: 'Frank is a friend'
+								}
+							}
+						}
+					}
+				}
+			});
+
+			const response = path.findPreferredExampleByRequest({});
+
+			assert.deepStrictEqual(response, undefined);
+
+		});
+
+		it('can determine preferred example by request content', () => {
+			const path = new Path({
+				uri: '/hello',
+				httpMethod: 'get',
+				parameters: undefined,
+				requestBody: {
+					required: true,
+					content: {
+						'text/plain': {
+							examples: {
+								simple: { value: 'hello' },
+								another: { value: 'testing' }
+							}
+						},
+						'application/text': {
+							examples: {
+								foo: { value: { name: 'Fred' } },
+								bar: { value: { name: 'Frank' } }
+							}
+						}
+					}
+				},
+				responses: {
+					200: {
+						description: 'OK',
+						content: {
+							'text/plain': {
+								examples: {
+									foo: 'Hello friend Fred',
+									bar: 'Frank is a friend'
+								}
+							}
+						}
+					}
+				}
+			});
+
+			const response = path.findPreferredExampleByRequest({ name: 'Frank' });
+
+			assert.deepStrictEqual(response, 'bar');
+
+		});
+	});
 });


### PR DESCRIPTION
In an effort to offer a solution to #66 this PR attempts to match the request body to a requestBody example and use the name of that example to find a corresponding response example.  This could be used as an alternative to supplying a `Prefer` header.