### PR TITLE
fix(Paths): Solve circular references

### DIFF
--- a/lib/open-api-mocker.js
+++ b/lib/open-api-mocker.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const jsonRefs = require('json-refs');
+const SwaggerParser = require('@apidevtools/swagger-parser');
 
 const { Parser: OpenApiParser } = require('./openapi');
 const { Parser: ServersParser } = require('./servers');
@@ -41,9 +41,7 @@ class OpenApiMocker {
 			this.schema = await this.schema;
 
 		try {
-			const parsedSchemas = await jsonRefs.resolveRefs(this.schema);
-
-			this.schema = parsedSchemas.resolved;
+			this.schema = await SwaggerParser.validate(this.schema);
 
 			const openApiParser = new OpenApiParser();
 			const openapi = openApiParser.parse(this.schema);

--- a/lib/open-api-mocker.js
+++ b/lib/open-api-mocker.js
@@ -10,6 +10,7 @@ const OpenAPISchemaInvalid = require('./errors/openapi-schema-invalid-error');
 
 const optionsBuilder = require('./utils/options-builder');
 const ExplicitSchemaLoader = require('./schema-loaders/explicit-loader');
+const replaceCircularReferencesFromObject = require('./utils/replace-circular-references-from-object');
 
 class OpenApiMocker {
 
@@ -48,6 +49,9 @@ class OpenApiMocker {
 
 			const serversParser = new ServersParser();
 			const servers = serversParser.parse(this.schema);
+
+			const defaultValue = {'type' : 'string'}
+			this.schema = replaceCircularReferencesFromObject(this.schema, defaultValue, 3);
 
 			const pathsParser = new PathsParser();
 			const paths = pathsParser.parse(this.schema);

--- a/lib/utils/replace-circular-references-from-object.js
+++ b/lib/utils/replace-circular-references-from-object.js
@@ -1,0 +1,76 @@
+/**
+ * Returns a copy of the given object without circular references.
+ * @param {Object} obj - The object to remove circular references from.
+ * @param {*} defaultValue - The default value to use for circular references.
+ * @param {number} circularReferencesLimit - The maximum number of circular references to allow before using the default value.
+ * @param {Array} [ancestors=[]] - An array of ancestor objects to check for circular references.
+ * @returns {Object} - A copy of the object without circular references.
+ */
+function replaceCircularReferencesFromObject(obj, defaultValue, circularReferencesLimit, ancestors = []) {
+  obj = getValue(obj, defaultValue, circularReferencesLimit, ancestors);
+  if (isObjectJSON(obj)) {
+    for (let key in obj) {
+      obj[key] = replaceCircularReferencesFromObject(
+        obj[key],
+        defaultValue,
+        circularReferencesLimit,
+        [...ancestors] // copy of ancestors avoiding mutation with siblings
+      );
+    }
+  }
+  return obj;
+}
+
+/**
+ * Returns a value without circular references.
+ * @param {*} value - The value to check for circular references.
+ * @param {*} defaultValue - The default value to return if a circular reference is found.
+ * @param {number} circularReferencesLimit - The maximum number of circular references to allow before using the default value.
+ * @param {Array} ancestors - An array of ancestors to check for circular references.
+ * @returns {*} - The value without circular references.
+ */
+function getValue(value, defaultValue, circularReferencesLimit, ancestors) {
+  if (typeof value !== 'object' || value === null) {
+    return value;
+  }
+  if (ancestors.includes(value)) {
+    if (countOccurrences(ancestors, value) >= circularReferencesLimit) {
+      return defaultValue;
+    } else {
+      ancestors.push(value); // push original reference
+      return Array.isArray(value) ? [...value] : { ...value };
+    }
+  }
+  ancestors.push(value);
+  return value;
+}
+
+/**
+ * Returns the number of occurrences of a value in an array.
+ * @param {Array} array - The array to check for occurrences.
+ * @param {*} value - The value to check for occurrences.
+ * @returns {number} - The number of occurrences of the value in the array.
+ */
+function countOccurrences(array, value) {
+  const count = array.reduce((accumulator, currentValue) => (currentValue === value ? accumulator + 1 : accumulator), 0);
+  return count;
+}
+
+/**
+ * Returns true if the object is a JSON object.
+ * @param {*} obj - The object to check.
+ * @returns {boolean} - True if the object is a JSON object.
+ */
+function isObjectJSON(obj) {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    !(obj instanceof Boolean) &&
+    !(obj instanceof Date) &&
+    !(obj instanceof Number) &&
+    !(obj instanceof RegExp) &&
+    !(obj instanceof String)
+  );
+}
+
+module.exports = replaceCircularReferencesFromObject;

--- a/lib/utils/replace-circular-references-from-object.js
+++ b/lib/utils/replace-circular-references-from-object.js
@@ -1,76 +1,78 @@
 /**
- * Returns a copy of the given object without circular references.
+ * Returns the given object without circular references.
+ * Replaces circular references with the given default value if the number of circular references exceeds the given depth limit.
  * @param {Object} obj - The object to remove circular references from.
- * @param {*} defaultValue - The default value to use for circular references.
- * @param {number} circularReferencesLimit - The maximum number of circular references to allow before using the default value.
- * @param {Array} [ancestors=[]] - An array of ancestor objects to check for circular references.
- * @returns {Object} - A copy of the object without circular references.
+ * @param {*} defaultValue - The default value to use for replacing circular references.
+ * @param {number} depthLimit - The maximum number of circular references allowed before using the default value.
+ * @returns {Object} - The object without circular references.
  */
-function replaceCircularReferencesFromObject(obj, defaultValue, circularReferencesLimit, ancestors = []) {
-  obj = getValue(obj, defaultValue, circularReferencesLimit, ancestors);
-  if (isObjectJSON(obj)) {
+function replaceCircularReferencesFromObject(obj, defaultValue, depthLimit) {
+  const circularReferenceReplacer = new CircularReferenceReplacer(defaultValue, depthLimit);
+  const objWithoutCircularReferences = circularReferenceReplacer.replace(obj);
+  return objWithoutCircularReferences;
+}
+
+class CircularReferenceReplacer {
+  #depthLimit;
+  #defaultValue;
+
+  /**
+   * @param {*} defaultValue - The default value to use for replacing circular references.
+   * @param {number} depthLimit - The maximum number of circular references allowed before using the default value.
+   */
+  constructor(defaultValue, depthLimit) {
+    this.#depthLimit = depthLimit;
+    this.#defaultValue = defaultValue;
+  }
+
+  replace(obj) {
+    return this.#replaceRecursively(obj, []);
+  }
+
+  #replaceRecursively(obj, ancestors) {
+    if (!this.#isJSONObjectOrArray(obj)) {
+      return obj;
+    }
+    if (this.#hasCircularReferences(obj, ancestors) && this.#exceedsDepthLimit(obj, ancestors)) {
+      return this.#defaultValue;
+    }
+    ancestors.push(obj); // push the original reference
+    obj = Array.isArray(obj) ? [...obj] : { ...obj };
     for (let key in obj) {
-      obj[key] = replaceCircularReferencesFromObject(
+      obj[key] = this.#replaceRecursively(
         obj[key],
-        defaultValue,
-        circularReferencesLimit,
-        [...ancestors] // copy of ancestors avoiding mutation with siblings
+        [...ancestors] // copy of ancestors avoiding mutation by siblings
       );
     }
+    return obj;
   }
-  return obj;
-}
 
-/**
- * Returns a value without circular references.
- * @param {*} value - The value to check for circular references.
- * @param {*} defaultValue - The default value to return if a circular reference is found.
- * @param {number} circularReferencesLimit - The maximum number of circular references to allow before using the default value.
- * @param {Array} ancestors - An array of ancestors to check for circular references.
- * @returns {*} - The value without circular references.
- */
-function getValue(value, defaultValue, circularReferencesLimit, ancestors) {
-  if (typeof value !== 'object' || value === null) {
-    return value;
+  #hasCircularReferences(obj, ancestors) {
+    const hasCircularReferences = ancestors.includes(obj);
+    return hasCircularReferences;
   }
-  if (ancestors.includes(value)) {
-    if (countOccurrences(ancestors, value) >= circularReferencesLimit) {
-      return defaultValue;
-    } else {
-      ancestors.push(value); // push original reference
-      return Array.isArray(value) ? [...value] : { ...value };
-    }
+
+  #exceedsDepthLimit(obj, ancestors) {
+    const exceedsCircularReferencesLimit = this.#countOccurrences(obj, ancestors) >= this.#depthLimit;
+    return exceedsCircularReferencesLimit;
   }
-  ancestors.push(value);
-  return value;
-}
 
-/**
- * Returns the number of occurrences of a value in an array.
- * @param {Array} array - The array to check for occurrences.
- * @param {*} value - The value to check for occurrences.
- * @returns {number} - The number of occurrences of the value in the array.
- */
-function countOccurrences(array, value) {
-  const count = array.reduce((accumulator, currentValue) => (currentValue === value ? accumulator + 1 : accumulator), 0);
-  return count;
-}
+  #countOccurrences(value, array) {
+    const count = array.reduce((accumulator, currentValue) => (currentValue === value ? accumulator + 1 : accumulator), 0);
+    return count;
+  }
 
-/**
- * Returns true if the object is a JSON object.
- * @param {*} obj - The object to check.
- * @returns {boolean} - True if the object is a JSON object.
- */
-function isObjectJSON(obj) {
-  return (
-    typeof obj === 'object' &&
-    obj !== null &&
-    !(obj instanceof Boolean) &&
-    !(obj instanceof Date) &&
-    !(obj instanceof Number) &&
-    !(obj instanceof RegExp) &&
-    !(obj instanceof String)
-  );
+  #isJSONObjectOrArray(obj) {
+    return (
+      typeof obj === 'object' &&
+      obj !== null &&
+      !(obj instanceof Boolean) &&
+      !(obj instanceof Date) &&
+      !(obj instanceof Number) &&
+      !(obj instanceof RegExp) &&
+      !(obj instanceof String)
+    );
+  }
 }
 
 module.exports = replaceCircularReferencesFromObject;

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "sinon": "^15.1.0"
   },
   "dependencies": {
+    "@apidevtools/swagger-parser": "^10.1.0",
     "@faker-js/faker": "^8.0.2",
     "ajv": "^6.12.6",
     "ajv-openapi": "^2.0.0",
@@ -48,7 +49,6 @@
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "js-yaml": "^4.1.0",
-    "json-refs": "^3.0.15",
     "lllog": "^1.1.2",
     "micro-memoize": "^4.1.2",
     "parse-prefer-header": "^1.0.0",


### PR DESCRIPTION
Schema objects with $ref to itself will cause a circular reference error

This solution handle this circular reference and allow setting a default value when circularReferencesLimit reached, which is set to 3.